### PR TITLE
ubus: only update TCP socket list when using TCP connections

### DIFF
--- a/src/utils/ubus.c
+++ b/src/utils/ubus.c
@@ -842,12 +842,11 @@ int dawn_init_ubus(const char *ubus_socket, const char *hostapd_dir) {
 
     ubus_add_oject();
 
-    start_umdns_update();
-
     if (network_config.network_option == 2)
     {
+        start_umdns_update();
         if(run_server(network_config.tcp_port))
-           uloop_timeout_set(&usock_timer, 1 * 1000);
+            uloop_timeout_set(&usock_timer, 1 * 1000);
     }
 
     subscribe_to_new_interfaces(hostapd_dir_glob);


### PR DESCRIPTION
DAWN currently tries to update it's list of TCP socket endpoints using
mDNS when it is configured to use UDP.

Only update the TCP socket list when DAWN is configured to use TCP
sockets.

Fix a identation mismatch along the way.