### PR TITLE
github: fix GitHub actions CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           path: dawn
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Extract OpenWrt SDK
         run: tar xf openwrt-sdk.tar.xz && mv openwrt-sdk-ath79-generic_gcc-8.4.0_musl.Linux-x86_64 sdk
       - name: Create config
-        run: make -C sdk defconfig
+        run: make -C sdk defconfig && echo "CONFIG_SRC_TREE_OVERRIDE=y" >> sdk/.config
       - name: Update package feed
         run: ./sdk/scripts/feeds update -a && ./sdk/scripts/feeds install -a
       - name: Link DAWN source

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Update package feed
         run: ./sdk/scripts/feeds update -a && ./sdk/scripts/feeds install -a
       - name: Link DAWN source
-        run: ln -s dawn/.git sdk/feeds/packages/net/dawn/git-src
+        run: ln -s $GITHUB_WORKSPACE/dawn/.git sdk/feeds/packages/net/dawn/git-src
       - name: Compile DAWN
         run: make -C sdk package/dawn/{clean,compile} V=s
       - name: Archive build output


### PR DESCRIPTION
This fixes various issues which lead to the CI always building the DAWN version from the packages feed.

Details about the individual changes can be found in the commit messages.