### PR TITLE
dawn_iwinfo: release iwinfo after usage

### DIFF
--- a/src/utils/dawn_iwinfo.c
+++ b/src/utils/dawn_iwinfo.c
@@ -224,9 +224,11 @@ int get_expected_throughput(const char *ifname, uint8_t *client_addr) {
 
     if (iw->assoclist(ifname, buf, &len)) {
         fprintf(stdout, "No information available\n");
+        iwinfo_finish();
         return INT_MIN;
     } else if (len <= 0) {
         fprintf(stdout, "No station connected\n");
+        iwinfo_finish();
         return INT_MIN;
     }
 


### PR DESCRIPTION
during daily usage, dawn often got killed by kernel. 

I check system log and found these words:
daemon.info dawn[11053]: No station connected
kern.info kernel: [30129.133933] do_page_fault(): sending SIGSEGV to dawn for invalid read access from 00000060

As a result, I checked every "No station connected" reference, and found this bug.