### PR TITLE
ubus: make decide_function consist with configuration

### DIFF
--- a/src/storage/datastorage.c
+++ b/src/storage/datastorage.c
@@ -427,7 +427,7 @@ int better_ap_available(uint8_t bssid_addr[], uint8_t client_addr[], char* neigh
             //return 1;
         }
 
-        if (dawn_metric.use_station_count && own_score == score_to_compare && score_to_compare > max_score) {
+        if (dawn_metric.use_station_count > 0 && own_score == score_to_compare && score_to_compare > max_score) {
 
             // only compare if score is bigger or equal 0
             if (own_score >= 0) {

--- a/src/utils/ubus.c
+++ b/src/utils/ubus.c
@@ -358,15 +358,15 @@ static int decide_function(probe_entry *prob_req, int req_type) {
         return 0;
     }
 
-    if (req_type == REQ_TYPE_PROBE && !dawn_metric.eval_probe_req) {
+    if (req_type == REQ_TYPE_PROBE && dawn_metric.eval_probe_req <= 0) {
         return 1;
     }
 
-    if (req_type == REQ_TYPE_AUTH && !dawn_metric.eval_auth_req) {
+    if (req_type == REQ_TYPE_AUTH && dawn_metric.eval_auth_req <= 0) {
         return 1;
     }
 
-    if (req_type == REQ_TYPE_ASSOC && !dawn_metric.eval_assoc_req) {
+    if (req_type == REQ_TYPE_ASSOC && dawn_metric.eval_assoc_req <= 0) {
         return 1;
     }
 


### PR DESCRIPTION
in luci-app-dawn, if eval_probe_req is not ticked, eval_probe_req would sometimes be -1.(this issue seldom appears)
however, in c language, !(-1) is false.
Since only zero in if statement is false, non-zero number is true.
