### PR TITLE
ubus/datastorage: don't repeatedly ask devices for beacon reports if they don't support it

### DIFF
--- a/src/include/datastorage.h
+++ b/src/include/datastorage.h
@@ -205,6 +205,7 @@ typedef struct client_s {
     time_t time;
     uint32_t aid;
     uint32_t kick_count;
+    uint8_t rrm_enabled_capa; //the first byte is enough
 } client;
 
 typedef struct ap_s {

--- a/src/storage/datastorage.c
+++ b/src/storage/datastorage.c
@@ -10,6 +10,13 @@
 
 #define MAC2STR(a) (a)[0], (a)[1], (a)[2], (a)[3], (a)[4], (a)[5]
 
+#ifndef BIT
+#define BIT(x) (1U << (x))
+#endif
+#define WLAN_RRM_CAPS_BEACON_REPORT_PASSIVE BIT(4)
+#define WLAN_RRM_CAPS_BEACON_REPORT_ACTIVE BIT(5)
+#define WLAN_RRM_CAPS_BEACON_REPORT_TABLE BIT(6)
+
 int go_next_help(char sort_order[], int i, probe_entry entry,
                  probe_entry next_entry);
 
@@ -68,7 +75,11 @@ void send_beacon_reports(uint8_t bssid[], int id) {
         if (!mac_is_equal(client_array[j].bssid_addr, bssid)) {
             break;
         }
-        ubus_send_beacon_report(client_array[j].client_addr, id);
+        if (client_array[j].rrm_enabled_capa & 
+            (WLAN_RRM_CAPS_BEACON_REPORT_PASSIVE |
+             WLAN_RRM_CAPS_BEACON_REPORT_ACTIVE | 
+             WLAN_RRM_CAPS_BEACON_REPORT_TABLE))
+            ubus_send_beacon_report(client_array[j].client_addr, id);
     }
     pthread_mutex_unlock(&client_array_mutex);
 }

--- a/src/utils/ubus.c
+++ b/src/utils/ubus.c
@@ -866,6 +866,32 @@ int dawn_init_ubus(const char *ubus_socket, const char *hostapd_dir) {
     return 0;
 }
 
+static uint8_t dump_rrm_data(void *data, int len, int type) //modify from examples/blobmsg-example.c in libubox
+{
+    uint32_t ret = 0;
+    switch(type) {
+    case BLOBMSG_TYPE_INT32:
+        ret = *(uint32_t *)data;
+        break;
+    default:
+        fprintf(stderr, "wrong type of rrm array\n");
+    }
+    return (uint8_t)ret;
+}
+
+static uint8_t
+dump_rrm_table(struct blob_attr *head, int len) //modify from examples/blobmsg-example.c in libubox
+{
+    struct blob_attr *attr;
+    uint8_t ret = 0;
+
+    __blob_for_each_attr(attr, head, len) {
+        ret = dump_rrm_data(blobmsg_data(attr), blobmsg_data_len(attr), blob_id(attr));
+        return ret;// get the first rrm byte
+    }
+    return ret;
+}
+
 // TOOD: Refactor this!
 static void
 dump_client(struct blob_attr **tb, uint8_t client_addr[], const char *bssid_addr, uint32_t freq, uint8_t ht_supported,
@@ -913,8 +939,11 @@ dump_client(struct blob_attr **tb, uint8_t client_addr[], const char *bssid_addr
     }
         /* RRM Caps */
     if (tb[CLIENT_TABLE_RRM]) {
+        client_entry.rrm_enabled_capa = dump_rrm_table(blobmsg_data(tb[CLIENT_TABLE_RRM]),
+                                            blobmsg_data_len(tb[CLIENT_TABLE_RRM]));// get the first byte from rrm array
         //ap_entry.ap_weight = blobmsg_get_u32(tb[CLIENT_TABLE_RRM]);
     } else {
+        client_entry.rrm_enabled_capa = 0;
         //ap_entry.ap_weight = 0;
     }
 


### PR DESCRIPTION
resolve issue #67

the simple rrm table decoder is from https://github.com/xfguo/libubox/blob/master/examples/blobmsg-example.c#L16-L58
and modified according to https://github.com/openwrt/openwrt/commit/21bb42fb8aa0c7ae2d81f5d49f9f4acf130cd444