### PR TITLE
malloc: add malloc failure wrapper

### DIFF
--- a/src/crypto/crypto.c
+++ b/src/crypto/crypto.c
@@ -67,6 +67,10 @@ char *gcrypt_encrypt_msg(char *msg, size_t msg_length, int *out_length) {
         msg_length += 0x10U - (msg_length & 0xfU);
 
     char *out = malloc(msg_length);
+    if (!out){
+        fprintf(stderr, "gcry_cipher_encrypt error: not enought memory\n");
+        return NULL;
+    } 
     gcry_error_handle = gcry_cipher_encrypt(gcry_cipher_hd, out, msg_length, msg, msg_length);
     if (gcry_error_handle) {
         fprintf(stderr, "gcry_cipher_encrypt failed:  %s/%s\n",
@@ -84,15 +88,24 @@ char *gcrypt_decrypt_msg(char *msg, size_t msg_length) {
         msg_length += 0x10U - (msg_length & 0xfU);
 
     char *out_buffer = malloc(msg_length);
+    if (!out_buffer){
+        fprintf(stderr, "gcry_cipher_decrypt error: not enought memory\n");
+        return NULL;
+    } 
     gcry_error_handle = gcry_cipher_decrypt(gcry_cipher_hd, out_buffer, msg_length, msg, msg_length);
     if (gcry_error_handle) {
-        fprintf(stderr, "gcry_cipher_encrypt failed:  %s/%s\n",
+        fprintf(stderr, "gcry_cipher_decrypt failed:  %s/%s\n",
                 gcry_strsource(gcry_error_handle),
                 gcry_strerror(gcry_error_handle));
         free(out_buffer);
         return NULL;
     }
     char *out = malloc(strlen(out_buffer) + 1);
+    if (!out){
+        free(out_buffer);
+        fprintf(stderr, "gcry_cipher_decrypt error: not enought memory\n");
+        return NULL;
+    }
     strcpy(out, out_buffer);
     free(out_buffer);
     return out;

--- a/src/network/tcpsocket.c
+++ b/src/network/tcpsocket.c
@@ -82,48 +82,30 @@ static void client_to_server_state(struct ustream *s) {
 static void client_read_cb(struct ustream *s, int bytes) {
     char *str;
     int len = 0;
-    uint32_t final_len;
-    int max_retry = 3, tried = 0;
+    uint32_t final_len = sizeof(uint32_t);
+    str = malloc(final_len);
 
-    do {
-        str = ustream_get_read_buf(s, &len);
-        if (!str)
-            break;
+    if ((len = ustream_read(s, str, final_len)) < final_len){//ensure recv sizeof(uint32_t).
+        fprintf(stderr,"not complete msg, len:%d, expected len:%u\n", len, final_len);
+        goto out;
+    }
+    
+    final_len = ntohl(*(uint32_t *)str) - sizeof(uint32_t);//the final_len in headder includes header itself
+    str = realloc(str, final_len);
+    if ((len = ustream_read(s, str, final_len)) < final_len) {//ensure recv final_len bytes.
+        fprintf(stderr,"not complete msg, len:%d, expected len:%u\n", len, final_len);
+        goto out;
+    }
 
-        if (network_config.use_symm_enc) {
-            final_len = ntohl(*(uint32_t *)str);
-            if(len < final_len) {//not complete msg, wait for next recv
-                fprintf(stderr,"not complete msg, len:%d, expected len:%u\n", len, final_len);
-                if (tried++ == max_retry) {
-                    ustream_consume(s, len);
-                    return;//drop package
-                }
-                continue;
-            }
-            char *dec = gcrypt_decrypt_msg(str+sizeof(final_len), final_len-sizeof(final_len));
-        
-            handle_network_msg(dec);
-            free(dec);
-            ustream_consume(s, final_len);//one msg is processed
-            tried = 0;
-        } else {
-            final_len = ntohl(*(uint32_t *)str);
-            if(len < final_len){
-                fprintf(stderr,"not complete msg, len:%d, expected len:%u\n", len, final_len);
-                if (tried++ == max_retry) {
-                    ustream_consume(s, len);
-                    return;
-                }
-                continue;
-            } 
-            char* msg = malloc(final_len);
-            memcpy(msg, str+sizeof(final_len), final_len-sizeof(final_len));
-            handle_network_msg(msg);
-            ustream_consume(s, final_len);//one msg is processed
-            free(msg);
-            tried = 0;
-        }
-    } while(1);
+    if (network_config.use_symm_enc) {        
+        char *dec = gcrypt_decrypt_msg(str, final_len);//len of str is final_len        
+        handle_network_msg(dec);
+        free(dec);
+    } else {
+        handle_network_msg(str);//len of str is final_len
+    }
+out:
+    free(str);
 }
 
 static void server_cb(struct uloop_fd *fd, unsigned int events) {


### PR DESCRIPTION
re-submit the ustream_read patch.
to ensure null pointer access is not caused by malloc failure,
this patch includes malloc failure wrapper.

if the issue #100  still exists, I would try to communicate with @PolynomialDivision.