### PR TITLE
tcpsocket: free con after ustream write error and make list each safe

### DIFF
--- a/src/network/tcpsocket.c
+++ b/src/network/tcpsocket.c
@@ -241,6 +241,7 @@ int add_tcp_conncection(char *ipv4, int port) {
 
 void send_tcp(char *msg) {
     print_tcp_array();
+    struct network_con_s *con, *tmp;
     if (network_config.use_symm_enc) {
         int length_enc;
         size_t msglen = strlen(msg)+1;
@@ -250,7 +251,6 @@ void send_tcp(char *msg) {
             return;
         } 
 
-        struct network_con_s *con;
         uint32_t final_len = length_enc + sizeof(final_len);
         char *final_str = malloc(final_len);
         if (!final_str){
@@ -261,14 +261,20 @@ void send_tcp(char *msg) {
         uint32_t *msg_header = (uint32_t *)final_str;
         *msg_header = htonl(final_len);
         memcpy(final_str+sizeof(final_len), enc, length_enc);
-        list_for_each_entry(con, &tcp_sock_list, list)
+        list_for_each_entry_safe(con, tmp, &tcp_sock_list, list)
         {
             if (con->connected) {
                 int len_ustream = ustream_write(&con->stream.stream, final_str, final_len, 0);
                 printf("Ustream send: %d\n", len_ustream);
                 if (len_ustream <= 0) {
                     fprintf(stderr,"Ustream error!\n");
-                    //TODO: ERROR HANDLING!
+                    //ERROR HANDLING!
+                    if (con->stream.stream.write_error) {
+                        ustream_free(&con->stream.stream);
+                        close(con->fd.fd);
+                        list_del(&con->list);
+                        free(con);
+                    } 
                 }
             }
 
@@ -287,16 +293,21 @@ void send_tcp(char *msg) {
         uint32_t *msg_header = (uint32_t *)final_str;
         *msg_header = htonl(final_len);
         memcpy(final_str+sizeof(final_len), msg, msglen);
-        struct network_con_s *con;
 
-        list_for_each_entry(con, &tcp_sock_list, list)
+        list_for_each_entry_safe(con, tmp, &tcp_sock_list, list)
         {
             if (con->connected) {
                 int len_ustream = ustream_write(&con->stream.stream, final_str, final_len, 0);
                 printf("Ustream send: %d\n", len_ustream);
                 if (len_ustream <= 0) {
-                    //TODO: ERROR HANDLING!
+                    //ERROR HANDLING!
                     fprintf(stderr,"Ustream error!\n");
+                    if (con->stream.stream.write_error) {
+                        ustream_free(&con->stream.stream);
+                        close(con->fd.fd);
+                        list_del(&con->list);
+                        free(con);
+                    } 
                 }
             }
         }


### PR DESCRIPTION
list_each is not safe against removal of list entry

this patch should eliminate the noisy Ustream error! log.