### PR TITLE
tcpsocket: add option to add server ip

### DIFF
--- a/src/include/datastorage.h
+++ b/src/include/datastorage.h
@@ -97,6 +97,7 @@ struct time_config_s {
 struct network_config_s {
     char broadcast_ip[MAX_IP_LENGTH];
     int broadcast_port;
+    char server_ip[MAX_IP_LENGTH];
     int tcp_port;
     int network_option;
     char shared_key[MAX_KEY_LENGTH];

--- a/src/include/ubus.h
+++ b/src/include/ubus.h
@@ -29,7 +29,7 @@ int dawn_init_ubus(const char *ubus_socket, const char *hostapd_dir);
 /**
  * Start the umdns timer for updating the zeroconfiguration properties.
  */
-void start_umdns_update();
+void start_tcp_con_update();
 
 /**
  * Call umdns update to update the TCP connections.

--- a/src/utils/dawn_uci.c
+++ b/src/utils/dawn_uci.c
@@ -138,6 +138,12 @@ struct network_config_s uci_get_dawn_network() {
             const char* str_broadcast = uci_lookup_option_string(uci_ctx, s, "broadcast_ip");
             strncpy(ret.broadcast_ip, str_broadcast, MAX_IP_LENGTH);
 
+            const char* str_server_ip = uci_lookup_option_string(uci_ctx, s, "server_ip");
+            if(str_server_ip)
+                strncpy(ret.server_ip, str_server_ip, MAX_IP_LENGTH);
+            else
+                ret.server_ip[0] = '\0';
+
             ret.broadcast_port = uci_lookup_option_int(uci_ctx, s, "broadcast_port");
 
             const char* str_shared_key = uci_lookup_option_string(uci_ctx, s, "shared_key");


### PR DESCRIPTION
A new config option allows to add a server ip
	option server_ip '10.0.0.2'

However, this server does not send anything back. Therefore it is not possible to change the node configuration. This will probably be added soon. The main goal of this commit is to allow monitoring of all nodes in a network with DAWN, e.g. clients, channel utilization, ...

Also a network option (3) has been added which allows to use TCP but not to announce your daemon in the broadcast domain. This allows you to create a monitor-only node that holds only the local information and forwards it to the central server.

A monitor-only node could be configured like
```
	option server_ip '10.0.0.1'
	option tcp_port '1026'
	option network_option '3'
```

Another possible config is
```
        option server_ip '10.0.0.1'
        option tcp_port '1026'
        option network_option '3'
```
Here, the node shares information with a central server, which can be located outside the broadcast domain. Nevertheless, it also shares information within its broadcast domain and can therefore perform client steering.