### PR TITLE
datastorage: fix hearingmap not synced

### DIFF
--- a/src/storage/datastorage.c
+++ b/src/storage/datastorage.c
@@ -1002,10 +1002,21 @@ probe_entry* insert_to_array(probe_entry* entry, int inc_counter, int save_80211
     // TODO: Add a packed / unpacked wrapper pair?
     probe_entry** existing_entry = probe_array_find_first_entry(entry->client_addr, entry->bssid_addr, true);
 
-    if (((*existing_entry) != NULL) && mac_is_equal_bb((*existing_entry)->client_addr, entry->client_addr) && mac_is_equal_bb((*existing_entry)->bssid_addr, entry->bssid_addr)) {
+    if (((*existing_entry) != NULL)
+            && mac_is_equal_bb((*existing_entry)->client_addr, entry->client_addr)
+            && mac_is_equal_bb((*existing_entry)->bssid_addr, entry->bssid_addr)) {
         (*existing_entry)->time = expiry;
         if (inc_counter)
             (*existing_entry)->counter++;
+
+        if (entry->signal)
+            (*existing_entry)->signal = entry->signal;
+
+        if(entry->ht_capabilities)
+            (*existing_entry)->ht_capabilities = entry->ht_capabilities;
+
+        if(entry->vht_capabilities)
+            (*existing_entry)->vht_capabilities = entry->vht_capabilities;
 
         if (save_80211k && entry->rcpi != -1)
             (*existing_entry)->rcpi = entry->rcpi;

--- a/src/utils/msghandler.c
+++ b/src/utils/msghandler.c
@@ -51,8 +51,8 @@ static const struct blobmsg_policy prob_policy[__PROB_MAX] = {
         [PROB_TARGET_ADDR] = {.name = "target", .type = BLOBMSG_TYPE_STRING},
         [PROB_SIGNAL] = {.name = "signal", .type = BLOBMSG_TYPE_INT32},
         [PROB_FREQ] = {.name = "freq", .type = BLOBMSG_TYPE_INT32},
-        [PROB_HT_CAPABILITIES] = {.name = "ht_capabilities", .type = BLOBMSG_TYPE_TABLE},
-        [PROB_VHT_CAPABILITIES] = {.name = "vht_capabilities", .type = BLOBMSG_TYPE_TABLE},
+        [PROB_HT_CAPABILITIES] = {.name = "ht_capabilities", .type = BLOBMSG_TYPE_TABLE}, //ToDo: Change to int8?
+        [PROB_VHT_CAPABILITIES] = {.name = "vht_capabilities", .type = BLOBMSG_TYPE_TABLE}, //ToDo: Change to int8?
         [PROB_RCPI] = {.name = "rcpi", .type = BLOBMSG_TYPE_INT32},
         [PROB_RSNI] = {.name = "rsni", .type = BLOBMSG_TYPE_INT32},
 };
@@ -283,7 +283,7 @@ int handle_network_msg(char* msg) {
     if (strncmp(method, "probe", 5) == 0) {
         probe_entry *entry = parse_to_probe_req(data_buf.head);
         if (entry != NULL) {
-            if (entry != insert_to_array(entry, false, false, false, time(0))) // use 802.11k values
+            if (entry != insert_to_array(entry, false, true, false, time(0))) // use 802.11k values
             {
                 // insert found an existing entry, rather than linking in our new one
                 dawn_free(entry);


### PR DESCRIPTION
The datastorage-refactoring changes an already existing entry instead of inserting and deleting it. However, it was forgotten to adopt some information from the new probe entry.

The ht_capabilities and vht_capabilities are now synced correctly.

RCPI and RSNI is now correctly synced.