### PR TITLE
ubus: fix rrm string callback function

### DIFF
--- a/src/utils/ubus.c
+++ b/src/utils/ubus.c
@@ -741,7 +741,7 @@ static void ubus_get_rrm_cb(struct ubus_request *req, int type, struct blob_attr
      {
          if(i==2)
          {
-            char* neighborreport = blobmsg_get_string(blobmsg_data(attr));
+            char* neighborreport = blobmsg_get_string(attr);
             strcpy(entry->neighbor_report,neighborreport);
             printf("Copied Neighborreport: %s,\n", entry->neighbor_report);
          }


### PR DESCRIPTION
The rrm_nr_get_own call returns an array. We need the 3rd value. We do not need to call blobmsg_data before blobmsg_get_string to extract the value. Additionally this causes strange behavior where an offset in the
string is accessed.