### PR TITLE
Take SSID into account when building the network map and neighbor reports

### DIFF
--- a/src/include/datastorage.h
+++ b/src/include/datastorage.h
@@ -122,12 +122,15 @@ extern struct probe_metric_s dawn_metric;
 
 /* Probe, Auth, Assoc */
 
+#define SSID_MAX_LEN 32
+
 // ---------------- Structs ----------------
 typedef struct probe_entry_s {
     struct probe_entry_s* next_probe;
     struct probe_entry_s* next_probe_skip;
     struct dawn_mac client_addr;
     struct dawn_mac bssid_addr;
+    uint8_t ssid[SSID_MAX_LEN + 1]; // parse_to_beacon_rep()
     struct dawn_mac target_addr; // TODO: Never evaluated?
     uint32_t signal; // eval_probe_metric()
     uint32_t freq; // eval_probe_metric()
@@ -170,7 +173,6 @@ typedef struct auth_entry_s assoc_entry;
 
 // ---------------- Defines ----------------
 
-#define SSID_MAX_LEN 32
 #define NEIGHBOR_REPORT_LEN 200
 
 // ---------------- Global variables ----------------
@@ -305,7 +307,7 @@ void remove_old_ap_entries(time_t current_time, long long int threshold);
 
 void print_ap_array();
 
-ap *ap_array_get_ap(struct dawn_mac bssid_mac);
+ap *ap_array_get_ap(struct dawn_mac bssid_mac, const uint8_t* ssid);
 
 int probe_array_set_all_probe_count(struct dawn_mac client_addr, uint32_t probe_count);
 

--- a/src/include/datastorage.h
+++ b/src/include/datastorage.h
@@ -227,7 +227,7 @@ typedef struct ap_s {
     uint32_t channel_utilization; // eval_probe_metric()
     time_t time; // remove_old...entries
     uint32_t station_count; // compare_station_count() <- better_ap_available()
-    uint8_t ssid[SSID_MAX_LEN]; // compare_sid() < -better_ap_available()
+    uint8_t ssid[SSID_MAX_LEN + 1]; // compare_sid() < -better_ap_available()
     char neighbor_report[NEIGHBOR_REPORT_LEN];
     uint32_t collision_domain;  // TODO: ap_get_collision_count() never evaluated?
     uint32_t bandwidth; // TODO: Never evaluated?

--- a/src/include/ubus.h
+++ b/src/include/ubus.h
@@ -78,7 +78,7 @@ int build_hearing_map_sort_client(struct blob_buf* b);
 
 int build_network_overview(struct blob_buf* b);
 
-int ap_get_nr(struct blob_buf* b, struct dawn_mac own_bssid_addr);
+int ap_get_nr(struct blob_buf* b, struct dawn_mac own_bssid_addr, const char *ssid);
 
 int parse_add_mac_to_file(struct blob_attr* msg);
 

--- a/src/test/test_storage.c
+++ b/src/test/test_storage.c
@@ -170,7 +170,7 @@ static int array_auto_helper(int action, int i0, int i1)
                 time_moves_on();
             }
             else
-                ap_array_delete(ap_array_get_ap(this_mac));
+                ap_array_delete(ap_array_get_ap(this_mac, NULL));
             break;
         case HELPER_CLIENT:
             ; // Empty statement to allow label before declaration
@@ -938,7 +938,7 @@ static int consume_actions(int argc, char* argv[], int harness_verbosity)
                 hwaddr_aton(argv[1], kick_mac.u8);
                 load_u32(&kick_id, argv[2]);
 
-                while ((kick_clients(ap_array_get_ap(kick_mac), kick_id) != 0) && safety_count--);
+                while ((kick_clients(ap_array_get_ap(kick_mac, NULL), kick_id) != 0) && safety_count--);
             }
         }
         else if (strcmp(*argv, "better_ap_available") == 0)
@@ -971,11 +971,11 @@ static int consume_actions(int argc, char* argv[], int harness_verbosity)
                         strcpy(nb, argv[4]);
                     }
 
-                    tr = better_ap_available(ap_array_get_ap(bssid_mac), client_mac, nb);
+                    tr = better_ap_available(ap_array_get_ap(bssid_mac, NULL), client_mac, nb);
                 }
                 else
                 {
-                    tr = better_ap_available(ap_array_get_ap(bssid_mac), client_mac, NULL);
+                    tr = better_ap_available(ap_array_get_ap(bssid_mac, NULL), client_mac, NULL);
                 }
 
                 printf("better_ap_available returned %d (with neighbour report %s)\n", tr, nb);
@@ -1000,7 +1000,7 @@ static int consume_actions(int argc, char* argv[], int harness_verbosity)
                 }
                 else
                 {
-                    ap* ap_entry = ap_array_get_ap(pr0->bssid_addr);
+                    ap* ap_entry = ap_array_get_ap(pr0->bssid_addr, NULL);
 
                     int this_metric = eval_probe_metric(pr0, ap_entry);
                     printf("eval_probe_metric: Returned %d\n", this_metric);

--- a/src/test/test_storage.c
+++ b/src/test/test_storage.c
@@ -697,7 +697,7 @@ static int consume_actions(int argc, char* argv[], int harness_verbosity)
             ap0->time = faketime;
             ap0->station_count = 0;
             memset(ap0->ssid, '*', SSID_MAX_LEN);
-            ap0->ssid[SSID_MAX_LEN - 1] = '\0';
+            ap0->ssid[SSID_MAX_LEN] = '\0';
             ap0->neighbor_report[0] = 0;
             ap0->collision_domain = 0;
             ap0->bandwidth = 0;

--- a/src/utils/dawn_iwinfo.c
+++ b/src/utils/dawn_iwinfo.c
@@ -281,8 +281,7 @@ int get_ssid(const char *ifname, char* ssid, size_t ssidmax) {
     if (iw->ssid(ifname, buf))
         memset(buf, 0, sizeof(buf));
 
-    memcpy(ssid, buf, ssidmax);
-    strcpy(ssid, buf);
+    strncpy(ssid, buf, ssidmax);
     iwinfo_finish();
     return 0;
 }

--- a/src/utils/ubus.c
+++ b/src/utils/ubus.c
@@ -867,7 +867,7 @@ void ubus_set_nr(){
         if (sub->subscribed) {
             int timeout = 1;
             blob_buf_init(&b_nr, 0);
-            ap_get_nr(&b_nr, sub->bssid_addr);
+            ap_get_nr(&b_nr, sub->bssid_addr, sub->ssid);
             ubus_invoke(ctx, sub->id, "rrm_nr_set", b_nr.head, NULL, NULL, timeout * 1000);
         }
     }
@@ -1563,7 +1563,7 @@ int build_network_overview(struct blob_buf *b) {
 
 // TODO: Does all APs constitute neighbor report?  How about using list of AP connected
 // clients can also see (from probe_set) to give more (physically) local set?
-int ap_get_nr(struct blob_buf *b_local, struct dawn_mac own_bssid_addr) {
+int ap_get_nr(struct blob_buf *b_local, struct dawn_mac own_bssid_addr, const char *ssid) {
 
     pthread_mutex_lock(&ap_array_mutex);
     ap *i;
@@ -1571,8 +1571,9 @@ int ap_get_nr(struct blob_buf *b_local, struct dawn_mac own_bssid_addr) {
     void* nbs = blobmsg_open_array(b_local, "list");
 
     for (i = ap_set; i != NULL; i = i->next_ap) {
-        if (mac_is_equal_bb(own_bssid_addr, i->bssid_addr)) {
-            continue; //TODO: Skip own entry?!
+        if (mac_is_equal_bb(own_bssid_addr, i->bssid_addr) ||
+	    strncmp((char *)i->ssid, ssid, SSID_MAX_LEN)) {
+            continue;
         }
 
         void* nr_entry = blobmsg_open_array(b_local, NULL);

--- a/src/utils/ubus.c
+++ b/src/utils/ubus.c
@@ -96,7 +96,7 @@ struct hostapd_sock_entry {
     char iface_name[MAX_INTERFACE_NAME];
     char hostname[HOST_NAME_MAX];
     struct dawn_mac bssid_addr;
-    char ssid[SSID_MAX_LEN];
+    char ssid[SSID_MAX_LEN + 1];
     uint8_t ht_support;
     uint8_t vht_support;
     uint64_t last_channel_time;
@@ -1214,6 +1214,7 @@ bool subscribe(struct hostapd_sock_entry *hostapd_entry) {
 
     get_bssid(hostapd_entry->iface_name, hostapd_entry->bssid_addr.u8);
     get_ssid(hostapd_entry->iface_name, hostapd_entry->ssid, (SSID_MAX_LEN) * sizeof(char));
+    hostapd_entry->ssid[SSID_MAX_LEN] = '\0';
 
     hostapd_entry->ht_support = (uint8_t) support_ht(hostapd_entry->iface_name);
     hostapd_entry->vht_support = (uint8_t) support_vht(hostapd_entry->iface_name);


### PR DESCRIPTION
The first commit in this series adds an extra byte to SSID strings to hold the NULL-byte termination, avoiding problems with some string functions.  Specifically, `get_ssid()` would write the termination null-byte outside of the ssid string if the ssid length is 32; I've changed `strcpy` to `strncpy` and remove the unnecessary `memcpy` above it to strengthen it some more.

Currently, `ap_array_get_ap` returns an entry by matching just the bssid, without checking if the ssid matches.  `ap_array_find_first_entry` does a binary search through the ap set without cheking the ssid, which is bad, as the list is sorted by SSID first, then by bssid_mac.  As a side effect, if you have more than one ssid, the network ap list grows unbounded over time.  This may fix #133.

Finally, the third commit in the series limits the neighbor list sent to hostapd to APs using the same SSID.  In theory there is nothing wrong with sending large neighbor reports with different SSIDs.  However, one would ordinarily roam to APs with the same SSID--802.11r, for example, will not work with different SSIDs.  It is good to keep the list small as well. Not just to save airtime, but [iOS devices only go through the first 6 entries when making roaming decisions](https://support.apple.com/en-us/HT203068).

I'm working on adding an UCI option to define a neighbor report priority list to help with that iOS top-6-entries limitation.

It's been tested with 7 Linksys E8450, running 3 SSIDs each.

I should have noted how long it took for the list to grown this big, but it went from 540kB:
```
# ubus call dawn get_network | sed -ne '/neighbor_report/{s/^.\{3\}\(.\{22\}\).\{8\}/\1xxxxxxxx/;p}' | sort | uniq -c
      1 "neighbor_report": "e8xxxxxxxx25ef090000510d070603000d00",
      1 "neighbor_report": "e8xxxxxxxx26ff5900008034090603023a00",
      1 "neighbor_report": "e8xxxxxxxx49ef0900005105070603000500",
      1 "neighbor_report": "e8xxxxxxxx4aff5900008074090603027a00",
      1 "neighbor_report": "e8xxxxxxxxc9ef0900005101070603000100",
      1 "neighbor_report": "e8xxxxxxxxcaef5900008095090603029b00",
      1 "neighbor_report": "e8xxxxxxxxcbef0900005101070603000100",
      1 "neighbor_report": "e8xxxxxxxxccef5900008024090603022a00",
      1 "neighbor_report": "e8xxxxxxxxcfef090000510d070603000d00",
      1 "neighbor_report": "e8xxxxxxxxd0ff5900008074090603027a00",
      1 "neighbor_report": "e8xxxxxxxxd1ef0900005109070603000900",
      1 "neighbor_report": "e8xxxxxxxxd2ff5900008084090603028a00",
      1 "neighbor_report": "e8xxxxxxxxf5ef0900005105070603000500",
      1 "neighbor_report": "e8xxxxxxxxf6ff5900008064090603026a00",
    110 "neighbor_report": "eaxxxxxxxx26ff5900008034090603023a00",
    140 "neighbor_report": "eaxxxxxxxx4aff5900008074090603027a00",
    140 "neighbor_report": "eaxxxxxxxxcaef5900008095090603029b00",
    139 "neighbor_report": "eaxxxxxxxxccef5900008024090603022a00",
    124 "neighbor_report": "eaxxxxxxxxd0ff5900008074090603027a00",
    105 "neighbor_report": "eaxxxxxxxxd2ff5900008084090603028a00",
    143 "neighbor_report": "eaxxxxxxxxf6ff5900008064090603026a00",
     92 "neighbor_report": "eexxxxxxxx26ff5900008034090603023a00",
    142 "neighbor_report": "eexxxxxxxx4aff5900008074090603027a00",
    151 "neighbor_report": "eexxxxxxxxcaef5900008095090603029b00",
    144 "neighbor_report": "eexxxxxxxxccef5900008024090603022a00",
    119 "neighbor_report": "eexxxxxxxxd0ff5900008074090603027a00",
     93 "neighbor_report": "eexxxxxxxxd2ff5900008084090603028a00",
    146 "neighbor_report": "eexxxxxxxxf6ff5900008064090603026a00",
```
... to 12KB:
```
# ubus call dawn get_network | sed -ne '/neighbor_report/{s/^.\{3\}\(.\{22\}\).\{8\}/\1xxxxxxxx/;p}' | sort | uniq -c
      1 "neighbor_report": "e8xxxxxxxx25ef090000510d070603000d00",
      1 "neighbor_report": "e8xxxxxxxx26ff5900008034090603023a00",
      1 "neighbor_report": "e8xxxxxxxx49ef0900005105070603000500",
      1 "neighbor_report": "e8xxxxxxxx4aff5900008074090603027a00",
      1 "neighbor_report": "e8xxxxxxxxc9ef0900005101070603000100",
      1 "neighbor_report": "e8xxxxxxxxcaef5900008095090603029b00",
      1 "neighbor_report": "e8xxxxxxxxcbef0900005101070603000100",
      1 "neighbor_report": "e8xxxxxxxxccef5900008024090603022a00",
      1 "neighbor_report": "e8xxxxxxxxcfef090000510d070603000d00",
      1 "neighbor_report": "e8xxxxxxxxd0ff5900008074090603027a00",
      1 "neighbor_report": "e8xxxxxxxxd1ef0900005109070603000900",
      1 "neighbor_report": "e8xxxxxxxxd2ff5900008084090603028a00",
      1 "neighbor_report": "e8xxxxxxxxf5ef0900005105070603000500",
      1 "neighbor_report": "e8xxxxxxxxf6ff5900008064090603026a00",
      1 "neighbor_report": "eaxxxxxxxx26ff5900008034090603023a00",
      1 "neighbor_report": "eaxxxxxxxx4aff5900008074090603027a00",
      1 "neighbor_report": "eaxxxxxxxxcaef5900008095090603029b00",
      1 "neighbor_report": "eaxxxxxxxxccef5900008024090603022a00",
      1 "neighbor_report": "eaxxxxxxxxd0ff5900008074090603027a00",
      1 "neighbor_report": "eaxxxxxxxxd2ff5900008084090603028a00",
      1 "neighbor_report": "eaxxxxxxxxf6ff5900008064090603026a00",
      1 "neighbor_report": "eexxxxxxxx26ff5900008034090603023a00",
      1 "neighbor_report": "eexxxxxxxx4aff5900008074090603027a00",
      1 "neighbor_report": "eexxxxxxxxcaef5900008095090603029b00",
      1 "neighbor_report": "eexxxxxxxxccef5900008024090603022a00",
      1 "neighbor_report": "eexxxxxxxxd0ff5900008074090603027a00",
      1 "neighbor_report": "eexxxxxxxxd2ff5900008084090603028a00",
      1 "neighbor_report": "eexxxxxxxxf6ff5900008064090603026a00",
```
Notice that interfaces with the first SSID (e8xxx), were not duplicated, but the other ones were.