### PR TITLE
msghandler: fix rrm array parsing

### DIFF
--- a/src/storage/datastorage.c
+++ b/src/storage/datastorage.c
@@ -395,6 +395,13 @@ void send_beacon_reports(struct dawn_mac bssid, int id) {
 
     // Go threw clients
     while (i != NULL && mac_is_equal_bb(i->bssid_addr, bssid)) {
+#ifndef DAWN_NO_OUTPUT
+        printf("Client " MACSTR ": rrm_enabled_capa=%02x: PASSIVE=%d, ACTIVE=%d, TABLE=%d\n",
+            MAC2STR(i->client_addr.u8), i->rrm_enabled_capa,
+            !!(i->rrm_enabled_capa & WLAN_RRM_CAPS_BEACON_REPORT_PASSIVE),
+            !!(i->rrm_enabled_capa & WLAN_RRM_CAPS_BEACON_REPORT_ACTIVE),
+            !!(i->rrm_enabled_capa & WLAN_RRM_CAPS_BEACON_REPORT_TABLE));
+#endif
         if (i->rrm_enabled_capa &
             (WLAN_RRM_CAPS_BEACON_REPORT_PASSIVE |
                 WLAN_RRM_CAPS_BEACON_REPORT_ACTIVE |

--- a/src/utils/msghandler.c
+++ b/src/utils/msghandler.c
@@ -328,30 +328,14 @@ int handle_network_msg(char* msg) {
     return 0;
 }
 
-static uint8_t dump_rrm_data(void* data, int len, int type) //modify from examples/blobmsg-example.c in libubox
-{
-    uint32_t ret = 0;
-    switch (type) {
-    case BLOBMSG_TYPE_INT32:
-        ret = *(uint32_t*)data;
-        break;
-    default:
-        fprintf(stderr, "wrong type of rrm array\n");
-    }
-    return (uint8_t)ret;
-}
-
 static uint8_t
-dump_rrm_table(struct blob_attr* head, int len) //modify from examples/blobmsg-example.c in libubox
+dump_rrm_data(struct blob_attr* head)
 {
-    struct blob_attr* attr;
-    uint8_t ret = 0;
-
-    __blob_for_each_attr(attr, head, len) {
-        ret = dump_rrm_data(blobmsg_data(attr), blobmsg_data_len(attr), blob_id(attr));
-        return ret;// get the first rrm byte
+    if (blob_id(head) != BLOBMSG_TYPE_INT32) {
+        fprintf(stderr, "wrong type of rrm array.\n");
+        return 0;
     }
-    return ret;
+    return (uint8_t)blobmsg_get_u32(head);
 }
 
 // TOOD: Refactor this!
@@ -406,8 +390,8 @@ dump_client(struct blob_attr** tb, struct dawn_mac client_addr, const char* bssi
     }
     /* RRM Caps */
     if (tb[CLIENT_RRM]) {
-        client_entry->rrm_enabled_capa = dump_rrm_table(blobmsg_data(tb[CLIENT_RRM]),
-            blobmsg_data_len(tb[CLIENT_RRM]));// get the first byte from rrm array
+        // get the first byte from rrm array
+        client_entry->rrm_enabled_capa = dump_rrm_data(blobmsg_data(tb[CLIENT_RRM]));
 //ap_entry.ap_weight = blobmsg_get_u32(tb[CLIENT_TABLE_RRM]);
     }
     else {


### PR DESCRIPTION
`dump_rrm_table` was called from `dump_client` with the pointer to the table data, not the table itself.

Instead of just fixing the call, I'm changing the table handling a bit.  Since only the first byte is needed, it can be fetched right away without looping through the table values, so we can just call `dump_rrm_data` passing the table data pointer.

There's an extra commit adding a debugging line showing the beacon capabilities values, along with the report types supported.

Tell me if you'd rather keep the table looping code, and if you want to keep the debugging line or not.  The latter may be useful to find appropriate values for the report type (`option mode`), as requested in #139.  

I have code that will compare the value of `mode` to the capabilities of the client, and select an appropriate value (prefer specified `mode` if supported, then fallback to `passive` (802.11 default), `active` and `beacon table` last).  This may be troublesome if one does not want to do active reports, or would rather take no action from a stale beacon table report (IIUC, the beacon table report contains the current data the the client has in its tables, but it is not clear to me how stale can that data be).