### PR TITLE
Change mode config parameter from int to string

### DIFF
--- a/src/include/datastorage.h
+++ b/src/include/datastorage.h
@@ -19,6 +19,15 @@
 
 // ---------------- Defines -------------------
 #define MAC_LIST_LENGTH 100
+#define DEFAULT_RRM_MODE_ORDER "pat"
+#define RRM_MODE_COUNT 3
+
+enum rrm_beacon_rqst_mode {
+    RRM_BEACON_RQST_MODE_PASSIVE,
+    RRM_BEACON_RQST_MODE_ACTIVE,
+    RRM_BEACON_RQST_MODE_BEACON_TABLE,
+    __RRM_BEACON_RQST_MODE_MAX
+};
 
 // ---------------- Global variables ----------------
 extern struct mac_entry_s *mac_set;
@@ -75,7 +84,8 @@ struct probe_metric_s {
     int kicking;
     int op_class;
     int duration;
-    int mode;
+    int rrm_mode_mask;
+    int rrm_mode_order[__RRM_BEACON_RQST_MODE_MAX];
     int scan_channel;
 };
 
@@ -174,6 +184,21 @@ typedef struct auth_entry_s assoc_entry;
 // ---------------- Defines ----------------
 
 #define NEIGHBOR_REPORT_LEN 200
+/* Neighbor report string elements
+ * [Elemen ID|1][LENGTH|1][BSSID|6][BSSID INFORMATION|4][Operating Class|1][Channel Number|1][PHY Type|1][Operational Subelements]
+ * first two bytes are not stored
+ */
+#define NR_BSSID         0
+#define NR_BSSID_INFO   12
+#define NR_OP_CLASS     20
+#define NR_CHANNEL      22
+#define NR_PHY          24
+#ifndef BIT
+#define BIT(x) (1U << (x))
+#endif
+#define WLAN_RRM_CAPS_BEACON_REPORT_PASSIVE BIT(4)
+#define WLAN_RRM_CAPS_BEACON_REPORT_ACTIVE BIT(5)
+#define WLAN_RRM_CAPS_BEACON_REPORT_TABLE BIT(6)
 
 // ---------------- Global variables ----------------
 extern struct auth_entry_s *denied_req_set;

--- a/src/include/ubus.h
+++ b/src/include/ubus.h
@@ -68,7 +68,7 @@ void del_client_all_interfaces(const struct dawn_mac client_addr, uint32_t reaso
  */
 void update_hostapd_sockets(struct uloop_timeout *t);
 
-void ubus_send_beacon_report(struct dawn_mac client, int id);
+void ubus_send_beacon_report(client *c, int id);
 
 void uloop_add_data_cbs();
 

--- a/src/storage/datastorage.c
+++ b/src/storage/datastorage.c
@@ -18,13 +18,6 @@ struct time_config_s timeout_config;
 
 #define MAC2STR(a) (a)[0], (a)[1], (a)[2], (a)[3], (a)[4], (a)[5]
 
-#ifndef BIT
-#define BIT(x) (1U << (x))
-#endif
-#define WLAN_RRM_CAPS_BEACON_REPORT_PASSIVE BIT(4)
-#define WLAN_RRM_CAPS_BEACON_REPORT_ACTIVE BIT(5)
-#define WLAN_RRM_CAPS_BEACON_REPORT_TABLE BIT(6)
-
 static int probe_compare(probe_entry *probe1, probe_entry *probe2);
 
 static int kick_client(ap *kicking_ap, struct client_s *client_entry, char* neighbor_report);
@@ -402,11 +395,8 @@ void send_beacon_reports(struct dawn_mac bssid, int id) {
             !!(i->rrm_enabled_capa & WLAN_RRM_CAPS_BEACON_REPORT_ACTIVE),
             !!(i->rrm_enabled_capa & WLAN_RRM_CAPS_BEACON_REPORT_TABLE));
 #endif
-        if (i->rrm_enabled_capa &
-            (WLAN_RRM_CAPS_BEACON_REPORT_PASSIVE |
-                WLAN_RRM_CAPS_BEACON_REPORT_ACTIVE |
-                WLAN_RRM_CAPS_BEACON_REPORT_TABLE))
-            ubus_send_beacon_report(i->client_addr, id);
+        if (i->rrm_enabled_capa & dawn_metric.rrm_mode_mask)
+            ubus_send_beacon_report(i, id);
 
         i = i->next_entry_bc;
     }

--- a/src/utils/msghandler.c
+++ b/src/utils/msghandler.c
@@ -586,7 +586,7 @@ enum {
     UCI_SET_HOSTAPD_NR,
     UCI_OP_CLASS,
     UCI_DURATION,
-    UCI_MODE,
+    UCI_RRM_MODE,
     UCI_SCAN_CHANNEL,
     __UCI_METIC_MAX
 };
@@ -639,8 +639,8 @@ static const struct blobmsg_policy uci_metric_policy[__UCI_METIC_MAX] = {
         [UCI_SET_HOSTAPD_NR] = {.name = "set_hostapd_nr", .type = BLOBMSG_TYPE_INT32},
         [UCI_OP_CLASS] = {.name = "op_class", .type = BLOBMSG_TYPE_INT32},
         [UCI_DURATION] = {.name = "duration", .type = BLOBMSG_TYPE_INT32},
-        [UCI_MODE] = {.name = "mode", .type = BLOBMSG_TYPE_INT32},
-        [UCI_SCAN_CHANNEL] = {.name = "mode", .type = BLOBMSG_TYPE_INT32},
+        [UCI_RRM_MODE] = {.name = "rrm_mode", .type = BLOBMSG_TYPE_STRING},
+        [UCI_SCAN_CHANNEL] = {.name = "scan_channel", .type = BLOBMSG_TYPE_INT32},
 };
 
 static const struct blobmsg_policy uci_times_policy[__UCI_TIMES_MAX] = {
@@ -752,7 +752,7 @@ static int handle_uci_config(struct blob_attr* msg) {
     sprintf(cmd_buffer, "dawn.@metric[0].duration=%d", blobmsg_get_u32(tb_metric[UCI_DURATION]));
     uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].mode=%d", blobmsg_get_u32(tb_metric[UCI_MODE]));
+    sprintf(cmd_buffer, "dawn.@metric[0].rrm_mode=%s", blobmsg_get_string(tb_metric[UCI_RRM_MODE]));
     uci_set_network(cmd_buffer);
 
     sprintf(cmd_buffer, "dawn.@metric[0].scan_channel=%d", blobmsg_get_u32(tb_metric[UCI_SCAN_CHANNEL]));


### PR DESCRIPTION
This renames `mode` to `rrm_mode`, and its type from int to string.
This way, we can set the correct mode for a probe request from the STA reported capabilities, along with the preferred order of modes, set by the `rrm_mode` uci config.

`rrm_mode` is a string of possible mode letters:
* `p` = passive report
* `a` = active report
* `b` or `t` = beacon table report.

Setting `rrm_mode='pat'`, will try to send passive reports, if available; if not, it will try an active report, using a beacon table if all else fails.

If you don't include a letter, the corresponding report type will be disabled.  An empty string will disable beacon reports.  Unrecognized letters are ignored, as well as repeated modes.  If the configuration is not present, a default value of `'pat'` will be used.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>


This will require changes to the luci package if we want to configure it from there.