### PR TITLE
RFC: Use different config values for 802.11a and 802.11g/b bands, plus more

### DIFF
--- a/src/include/datastorage.h
+++ b/src/include/datastorage.h
@@ -52,6 +52,11 @@ void mac_array_delete(struct mac_entry_s* entry);
 // ---------------- Global variables ----------------
 /*** Metrics and configuration data ***/
 
+// TODO: Define a proper version string
+#ifndef DAWN_CONFIG_VERSION
+#define DAWN_CONFIG_VERSION "1"
+#endif
+
 // ---------------- Structs ----------------
 struct probe_metric_s {
     int ap_weight; // TODO: Never evaluated?

--- a/src/include/datastorage.h
+++ b/src/include/datastorage.h
@@ -48,31 +48,34 @@ struct mac_entry_s* insert_to_mac_array(struct mac_entry_s* entry, struct mac_en
 
 void mac_array_delete(struct mac_entry_s* entry);
 
+int get_band(int freq);
 
 // ---------------- Global variables ----------------
 /*** Metrics and configuration data ***/
 
 // TODO: Define a proper version string
 #ifndef DAWN_CONFIG_VERSION
-#define DAWN_CONFIG_VERSION "1"
+#define DAWN_CONFIG_VERSION "2"
 #endif
+
+// Band definitions
+// Keep them sorted by frequency, in ascending order
+enum dawn_bands {
+    DAWN_BAND_80211G,
+    DAWN_BAND_80211A,
+    __DAWN_BAND_MAX
+};
+
+// config section name
+extern const char *band_config_name[__DAWN_BAND_MAX];
+
+// starting frequency
+// TODO: make this configurable
+extern const int max_band_freq[__DAWN_BAND_MAX];
 
 // ---------------- Structs ----------------
 struct probe_metric_s {
-    int ap_weight; // TODO: Never evaluated?
-    int ht_support; // eval_probe_metric()()
-    int vht_support; // eval_probe_metric()()
-    int no_ht_support; // eval_probe_metric()()
-    int no_vht_support; // eval_probe_metric()()
-    int rssi; // eval_probe_metric()()
-    int low_rssi; // eval_probe_metric()()
-    int freq; // eval_probe_metric()()
-    int chan_util; // eval_probe_metric()()
-    int max_chan_util; // eval_probe_metric()()
-    int rssi_val; // eval_probe_metric()()
-    int low_rssi_val; // eval_probe_metric()()
-    int chan_util_val; // eval_probe_metric()()
-    int max_chan_util_val; // eval_probe_metric()()
+    // Global Configuration
     int min_probe_count;
     int bandwidth_threshold; // kick_clients()
     int use_station_count; // better_ap_available()
@@ -83,13 +86,29 @@ struct probe_metric_s {
     int deny_auth_reason;
     int deny_assoc_reason;
     int use_driver_recog;
-    int min_kick_count; // kick_clients()
+    int min_number_to_kick; // kick_clients()
     int chan_util_avg_period;
     int set_hostapd_nr;
     int kicking;
     int duration;
     int rrm_mode_mask;
     int rrm_mode_order[__RRM_BEACON_RQST_MODE_MAX];
+
+    // Per-band Configuration
+    int ap_weight[__DAWN_BAND_MAX]; // TODO: Never evaluated?
+    int ht_support[__DAWN_BAND_MAX]; // eval_probe_metric()()
+    int vht_support[__DAWN_BAND_MAX]; // eval_probe_metric()()
+    int no_ht_support[__DAWN_BAND_MAX]; // eval_probe_metric()()
+    int no_vht_support[__DAWN_BAND_MAX]; // eval_probe_metric()()
+    int rssi[__DAWN_BAND_MAX]; // eval_probe_metric()()
+    int low_rssi[__DAWN_BAND_MAX]; // eval_probe_metric()()
+    int freq[__DAWN_BAND_MAX]; // eval_probe_metric()()
+    int chan_util[__DAWN_BAND_MAX]; // eval_probe_metric()()
+    int max_chan_util[__DAWN_BAND_MAX]; // eval_probe_metric()()
+    int rssi_val[__DAWN_BAND_MAX]; // eval_probe_metric()()
+    int low_rssi_val[__DAWN_BAND_MAX]; // eval_probe_metric()()
+    int chan_util_val[__DAWN_BAND_MAX]; // eval_probe_metric()()
+    int max_chan_util_val[__DAWN_BAND_MAX]; // eval_probe_metric()()
 };
 
 struct time_config_s {

--- a/src/include/datastorage.h
+++ b/src/include/datastorage.h
@@ -109,6 +109,7 @@ struct probe_metric_s {
     int low_rssi_val[__DAWN_BAND_MAX]; // eval_probe_metric()()
     int chan_util_val[__DAWN_BAND_MAX]; // eval_probe_metric()()
     int max_chan_util_val[__DAWN_BAND_MAX]; // eval_probe_metric()()
+    struct mac_entry_s* neighbors[__DAWN_BAND_MAX]; // ap_get_nr()
 };
 
 struct time_config_s {
@@ -250,7 +251,7 @@ typedef struct client_s {
     char signature[SIGNATURE_LEN]; // TODO: Never evaluated?
     uint8_t ht_supported; // TODO: Never evaluated?
     uint8_t vht_supported; // TODO: Never evaluated?
-    uint32_t freq; // TODO: Never evaluated?
+    uint32_t freq; // ap_get_nr()
     uint8_t auth; // TODO: Never evaluated?
     uint8_t assoc; // TODO: Never evaluated?
     uint8_t authorized; // TODO: Never evaluated?

--- a/src/include/datastorage.h
+++ b/src/include/datastorage.h
@@ -361,9 +361,7 @@ ap *ap_array_get_ap(struct dawn_mac bssid_mac, const uint8_t* ssid);
 
 int probe_array_set_all_probe_count(struct dawn_mac client_addr, uint32_t probe_count);
 
-#ifndef DAWN_NO_OUTPUT
 int ap_get_collision_count(int col_domain);
-#endif
 
 void send_beacon_reports(ap *a, int id);
 

--- a/src/include/datastorage.h
+++ b/src/include/datastorage.h
@@ -347,9 +347,14 @@ void send_beacon_reports(ap *a, int id);
 #define SORT_LENGTH 5
 extern char sort_string[];
 
+struct kicking_nr {
+    char nr[NEIGHBOR_REPORT_LEN];
+    int score;
+    struct kicking_nr *next;
+};
 
 // ---------------- Functions -------------------
-int better_ap_available(ap *kicking_ap, struct dawn_mac client_addr, char* neighbor_report);
+int better_ap_available(ap *kicking_ap, struct dawn_mac client_addr, struct kicking_nr** neighbor_report);
 
 // All users of datastorage should call init_ / destroy_mutex at initialisation and termination respectively
 int init_mutex();

--- a/src/include/datastorage.h
+++ b/src/include/datastorage.h
@@ -55,7 +55,7 @@ int get_band(int freq);
 
 // TODO: Define a proper version string
 #ifndef DAWN_CONFIG_VERSION
-#define DAWN_CONFIG_VERSION "2"
+#define DAWN_CONFIG_VERSION "3"
 #endif
 
 // Band definitions
@@ -90,11 +90,13 @@ struct probe_metric_s {
     int chan_util_avg_period;
     int set_hostapd_nr;
     int kicking;
+    int kicking_threshold;
     int duration;
     int rrm_mode_mask;
     int rrm_mode_order[__RRM_BEACON_RQST_MODE_MAX];
 
     // Per-band Configuration
+    int initial_score[__DAWN_BAND_MAX]; // eval_probe_metric()()
     int ap_weight[__DAWN_BAND_MAX]; // TODO: Never evaluated?
     int ht_support[__DAWN_BAND_MAX]; // eval_probe_metric()()
     int vht_support[__DAWN_BAND_MAX]; // eval_probe_metric()()
@@ -102,13 +104,14 @@ struct probe_metric_s {
     int no_vht_support[__DAWN_BAND_MAX]; // eval_probe_metric()()
     int rssi[__DAWN_BAND_MAX]; // eval_probe_metric()()
     int low_rssi[__DAWN_BAND_MAX]; // eval_probe_metric()()
-    int freq[__DAWN_BAND_MAX]; // eval_probe_metric()()
     int chan_util[__DAWN_BAND_MAX]; // eval_probe_metric()()
     int max_chan_util[__DAWN_BAND_MAX]; // eval_probe_metric()()
     int rssi_val[__DAWN_BAND_MAX]; // eval_probe_metric()()
     int low_rssi_val[__DAWN_BAND_MAX]; // eval_probe_metric()()
     int chan_util_val[__DAWN_BAND_MAX]; // eval_probe_metric()()
     int max_chan_util_val[__DAWN_BAND_MAX]; // eval_probe_metric()()
+    int rssi_weight[__DAWN_BAND_MAX]; // eval_probe_metric()()
+    int rssi_center[__DAWN_BAND_MAX]; // eval_probe_metric()()
     struct mac_entry_s* neighbors[__DAWN_BAND_MAX]; // ap_get_nr()
 };
 

--- a/src/include/datastorage.h
+++ b/src/include/datastorage.h
@@ -82,11 +82,9 @@ struct probe_metric_s {
     int chan_util_avg_period;
     int set_hostapd_nr;
     int kicking;
-    int op_class;
     int duration;
     int rrm_mode_mask;
     int rrm_mode_order[__RRM_BEACON_RQST_MODE_MAX];
-    int scan_channel;
 };
 
 struct time_config_s {
@@ -248,7 +246,7 @@ typedef struct client_s {
 typedef struct ap_s {
     struct ap_s* next_ap;
     struct dawn_mac bssid_addr;
-    uint32_t freq; // TODO: Never evaluated?
+    uint32_t freq; // ap_get_nr()
     uint8_t ht_support; // eval_probe_metric()
     uint8_t vht_support; // eval_probe_metric()
     uint32_t channel_utilization; // eval_probe_metric()
@@ -256,6 +254,8 @@ typedef struct ap_s {
     uint32_t station_count; // compare_station_count() <- better_ap_available()
     uint8_t ssid[SSID_MAX_LEN + 1]; // compare_sid() < -better_ap_available()
     char neighbor_report[NEIGHBOR_REPORT_LEN];
+    uint32_t op_class; // ubus_send_beacon_report()
+    uint32_t channel; // ubus_send_beacon_report()
     uint32_t collision_domain;  // TODO: ap_get_collision_count() never evaluated?
     uint32_t bandwidth; // TODO: Never evaluated?
     uint32_t ap_weight; // eval_probe_metric()
@@ -340,7 +340,7 @@ int probe_array_set_all_probe_count(struct dawn_mac client_addr, uint32_t probe_
 int ap_get_collision_count(int col_domain);
 #endif
 
-void send_beacon_reports(struct dawn_mac bssid, int id);
+void send_beacon_reports(ap *a, int id);
 
 /* Utils */
 // deprecate use of this - it makes things slow

--- a/src/include/mac_utils.h
+++ b/src/include/mac_utils.h
@@ -10,6 +10,9 @@
 #define MACSTR "%02X:%02X:%02X:%02X:%02X:%02X"
 #define MACSTRLOWER "%02x:%02x:%02x:%02x:%02x:%02x"
 
+#define NR_MACSTR "%c%c:%c%c:%c%c:%c%c:%c%c:%c%c"
+#define NR_MAC2STR(a) *a, *(a+1), *(a+2), *(a+3), *(a+4), *(a+5), *(a+6), *(a+7), *(a+8), *(a+9), *(a+10), *(a+11)
+
 #ifndef ETH_ALEN
 #define ETH_ALEN 6
 #endif

--- a/src/include/ubus.h
+++ b/src/include/ubus.h
@@ -68,7 +68,7 @@ void del_client_all_interfaces(const struct dawn_mac client_addr, uint32_t reaso
  */
 void update_hostapd_sockets(struct uloop_timeout *t);
 
-void ubus_send_beacon_report(client *c, int id);
+void ubus_send_beacon_report(client *c, ap *a, int id);
 
 void uloop_add_data_cbs();
 

--- a/src/include/ubus.h
+++ b/src/include/ubus.h
@@ -139,7 +139,7 @@ int send_set_probe(struct dawn_mac client_addr);
  * @param duration
  * @return - 0 = asynchronous (client has been told to remove itself, and caller should manage arrays); 1 = synchronous (caller should assume arrays are updated)
  */
-int wnm_disassoc_imminent(uint32_t id, const struct dawn_mac client_addr, char* dest_ap, uint32_t duration);
+int wnm_disassoc_imminent(uint32_t id, const struct dawn_mac client_addr, struct kicking_nr* neighbor_list, uint32_t duration);
 
 /**
  * Send control message to all hosts to add the mac to a don't control list.

--- a/src/network/networksocket.c
+++ b/src/network/networksocket.c
@@ -37,7 +37,9 @@ int init_socket_runopts(const char *_ip, int _port, int _multicast_socket) {
     multicast_socket = _multicast_socket;
 
     if (multicast_socket) {
+#ifndef DAWN_NO_OUTPUT
         printf("Settingup multicastsocket!\n");
+#endif
         sock = setup_multicast_socket(ip, port, &addr);
     } else {
         sock = setup_broadcast_socket(ip, port, &addr);
@@ -56,7 +58,9 @@ int init_socket_runopts(const char *_ip, int _port, int _multicast_socket) {
         }
     }
 
+#ifndef DAWN_NO_OUTPUT
     fprintf(stdout, "Connected to %s:%d\n", ip, port);
+#endif
 
     return 0;
 }
@@ -79,7 +83,9 @@ void *receive_msg(void *args) {
         }
         recv_string[recv_string_len] = '\0';
 
+#ifndef DAWN_NO_OUTPUT
         printf("Received network message: %s\n", recv_string);
+#endif
         handle_network_msg(recv_string);
     }
 }
@@ -115,7 +121,9 @@ void *receive_msg_enc(void *args) {
             return 0;
         }
 
+#ifndef DAWN_NO_OUTPUT
         printf("Received network message: %s\n", dec);
+#endif
         dawn_free(base64_dec_str);
         handle_network_msg(dec);
         dawn_free(dec);

--- a/src/network/tcpsocket.c
+++ b/src/network/tcpsocket.c
@@ -97,8 +97,10 @@ static void client_read_cb(struct ustream *s, int bytes) {
     while(1) {
         if (cl->state == READ_STATUS_READY)
         {
+#ifndef DAWN_NO_OUTPUT
             printf("tcp_socket: commencing message...\n");
             uint32_t min_len = sizeof(uint32_t); // big enough to get msg length
+#endif
             cl->str = dawn_malloc(HEADER_SIZE);
             if (!cl->str) {
                 fprintf(stderr,"not enough memory (" STR_QUOTE(__LINE__) ")\n");
@@ -108,7 +110,9 @@ static void client_read_cb(struct ustream *s, int bytes) {
             uint32_t avail_len = ustream_pending_data(s, false);
 
             if (avail_len < HEADER_SIZE){//ensure recv sizeof(uint32_t)
+#ifndef DAWN_NO_OUTPUT
                 printf("not complete msg, len:%d, expected len:%u\n", avail_len, min_len);
+#endif
                 dawn_free(cl->str);
                 cl->str = NULL;
                 break;
@@ -142,7 +146,9 @@ static void client_read_cb(struct ustream *s, int bytes) {
 
         if (cl->state == READ_STATUS_COMMENCED)
         {
+#ifndef DAWN_NO_OUTPUT
             printf("tcp_socket: reading message...\n");
+#endif
             uint32_t read_len = ustream_pending_data(s, false);
 
             if (read_len == 0)
@@ -151,22 +157,30 @@ static void client_read_cb(struct ustream *s, int bytes) {
             if (read_len > (cl->final_len - cl->curr_len))
                     read_len = cl->final_len - cl->curr_len;
 
+#ifndef DAWN_NO_OUTPUT
             printf("tcp_socket: reading %" PRIu32 " bytes to add to %" PRIu32 " of %" PRIu32 "...\n",
                     read_len, cl->curr_len, cl->final_len);
+#endif
 
             uint32_t this_read = ustream_read(s, cl->str + cl->curr_len, read_len);
             cl->curr_len += this_read;
+#ifndef DAWN_NO_OUTPUT
             printf("tcp_socket: ...and we're back, now have %" PRIu32 " bytes\n", cl->curr_len);
+#endif
             if (cl->curr_len == cl->final_len){//ensure recv final_len bytes.
                 // Full message now received
                 cl->state = READ_STATUS_COMPLETE;
+#ifndef DAWN_NO_OUTPUT
                 printf("tcp_socket: message completed\n");
+#endif
             }
         }
 
         if (cl->state == READ_STATUS_COMPLETE)
         {
+#ifndef DAWN_NO_OUTPUT
             printf("tcp_socket: processing message...\n");
+#endif
             if (network_config.use_symm_enc) {
                 char *dec = gcrypt_decrypt_msg(cl->str + HEADER_SIZE, cl->final_len - HEADER_SIZE);//len of str is final_len
                 if (!dec) {
@@ -189,7 +203,9 @@ static void client_read_cb(struct ustream *s, int bytes) {
         }
     }
 
+#ifndef DAWN_NO_OUTPUT
     printf("tcp_socket: leaving\n");
+#endif
 
     return;
 }
@@ -220,7 +236,9 @@ static void server_cb(struct uloop_fd *fd, unsigned int events) {
 }
 
 int run_server(int port) {
+#ifndef DAWN_NO_OUTPUT
     printf("Adding socket!\n");
+#endif
     char port_str[12];
     sprintf(port_str, "%d", port);
 
@@ -242,7 +260,9 @@ static void client_not_be_used_read_cb(struct ustream *s, int bytes) {
 
     len = ustream_read(s, buf, sizeof(buf));
     buf[len] = '\0';
+#ifndef DAWN_NO_OUTPUT
     printf("Read %d bytes from SSL connection: %s\n", len, buf);
+#endif
 }
 
 static void connect_cb(struct uloop_fd *f, unsigned int events) {
@@ -257,7 +277,9 @@ static void connect_cb(struct uloop_fd *f, unsigned int events) {
         return;
     }
 
+#ifndef DAWN_NO_OUTPUT
     fprintf(stderr, "Connection established\n");
+#endif
     uloop_fd_delete(&entry->fd);
 
     entry->stream.stream.notify_read = client_not_be_used_read_cb;
@@ -302,7 +324,9 @@ int add_tcp_conncection(char *ipv4, int port) {
     tcp_entry->fd.cb = connect_cb;
     uloop_fd_add(&tcp_entry->fd, ULOOP_WRITE | ULOOP_EDGE_TRIGGER);
 
+#ifndef DAWN_NO_OUTPUT
     printf("New TCP connection to %s:%d\n", ipv4, port);
+#endif
     list_add(&tcp_entry->list, &tcp_sock_list);
 
     return 0;
@@ -334,7 +358,9 @@ void send_tcp(char *msg) {
         {
             if (con->connected) {
                 int len_ustream = ustream_write(&con->stream.stream, final_str, final_len, 0);
+#ifndef DAWN_NO_OUTPUT
                 printf("Ustream send: %d\n", len_ustream);
+#endif
                 if (len_ustream <= 0) {
                     fprintf(stderr,"Ustream error(" STR_QUOTE(__LINE__) ")!\n");
                     //ERROR HANDLING!
@@ -367,7 +393,9 @@ void send_tcp(char *msg) {
         {
             if (con->connected) {
                 int len_ustream = ustream_write(&con->stream.stream, final_str, final_len, 0);
+#ifndef DAWN_NO_OUTPUT
                 printf("Ustream send: %d\n", len_ustream);
+#endif
                 if (len_ustream <= 0) {
                     //ERROR HANDLING!
                     fprintf(stderr,"Ustream error(" STR_QUOTE(__LINE__) ")!\n");
@@ -398,6 +426,7 @@ struct network_con_s* tcp_list_contains_address(struct sockaddr_in entry) {
 }
 
 void print_tcp_array() {
+#ifndef DAWN_NO_OUTPUT
     struct network_con_s *con;
 
     printf("--------Connections------\n");
@@ -406,4 +435,5 @@ void print_tcp_array() {
         printf("Connecting to Port: %d, Connected: %s\n", ntohs(con->sock_addr.sin_port), con->connected ? "True" : "False");
     }
     printf("------------------\n");
+#endif
 }

--- a/src/storage/datastorage.c
+++ b/src/storage/datastorage.c
@@ -380,14 +380,14 @@ static struct mac_entry_s** mac_find_first_entry(struct dawn_mac mac)
     return lo_ptr;
 }
 
-void send_beacon_reports(struct dawn_mac bssid, int id) {
+void send_beacon_reports(ap *a, int id) {
     pthread_mutex_lock(&client_array_mutex);
 
     // Seach for BSSID
-    client* i = *client_find_first_bc_entry(bssid, dawn_mac_null, false);
+    client* i = *client_find_first_bc_entry(a->bssid_addr, dawn_mac_null, false);
 
     // Go threw clients
-    while (i != NULL && mac_is_equal_bb(i->bssid_addr, bssid)) {
+    while (i != NULL && mac_is_equal_bb(i->bssid_addr, a->bssid_addr)) {
 #ifndef DAWN_NO_OUTPUT
         printf("Client " MACSTR ": rrm_enabled_capa=%02x: PASSIVE=%d, ACTIVE=%d, TABLE=%d\n",
             MAC2STR(i->client_addr.u8), i->rrm_enabled_capa,
@@ -396,7 +396,7 @@ void send_beacon_reports(struct dawn_mac bssid, int id) {
             !!(i->rrm_enabled_capa & WLAN_RRM_CAPS_BEACON_REPORT_TABLE));
 #endif
         if (i->rrm_enabled_capa & dawn_metric.rrm_mode_mask)
-            ubus_send_beacon_report(i, id);
+            ubus_send_beacon_report(i, a, id);
 
         i = i->next_entry_bc;
     }

--- a/src/storage/datastorage.c
+++ b/src/storage/datastorage.c
@@ -479,16 +479,10 @@ static int compare_station_count(ap* ap_entry_own, ap* ap_entry_to_compare, stru
     int sta_count = ap_entry_own->station_count;
     int sta_count_to_compare = ap_entry_to_compare->station_count;
     if (is_connected(ap_entry_own->bssid_addr, client_addr)) {
-#ifndef DAWN_NO_OUTPUT
-        printf("Own is already connected! Decrease counter!\n");
-#endif
         sta_count--;
     }
 
     if (is_connected(ap_entry_to_compare->bssid_addr, client_addr)) {
-#ifndef DAWN_NO_OUTPUT
-        printf("Comparing station is already connected! Decrease counter!\n");
-#endif
         sta_count_to_compare--;
     }
 #ifndef DAWN_NO_OUTPUT
@@ -582,10 +576,6 @@ int better_ap_available(ap *kicking_ap, struct dawn_mac client_mac, struct kicki
 
     while (i != NULL && mac_is_equal_bb(i->client_addr, client_mac)) {
         if (i == own_probe) {
-#ifndef DAWN_NO_OUTPUT
-            printf("Own Score! Skipping!\n");
-            print_probe_entry(i);
-#endif
             i = i->next_probe;
             continue;
         }
@@ -829,11 +819,6 @@ void update_iw_info(struct dawn_mac bssid_mac) {
                 printf("Failed to update rssi!\n");
 #endif
             }
-            else {
-#ifndef DAWN_NO_OUTPUT
-                printf("Updated rssi: %d\n", rssi);
-#endif
-            }
         }
     }
 
@@ -1064,9 +1049,6 @@ int probe_array_set_all_probe_count(struct dawn_mac client_addr, uint32_t probe_
     pthread_mutex_lock(&probe_array_mutex);
     for (probe_entry *i = probe_set; i != NULL; i = i->next_probe) {
         if (mac_is_equal_bb(client_addr, i->client_addr)) {
-#ifndef DAWN_NO_OUTPUT
-            printf("Setting probecount for given mac!\n");
-#endif
             i->counter = probe_count;
         } else if (mac_compare_bb(client_addr, i->client_addr) > 0) {
 #ifndef DAWN_NO_OUTPUT
@@ -1423,11 +1405,6 @@ void insert_macs_from_file() {
             old_line = line;
             dawn_regmem(old_line);
         }
-#endif
-
-#ifndef DAWN_NO_OUTPUT
-        printf("Retrieved line of length %zu :\n", read);
-        printf("%s", line);
 #endif
 
         // Need to scanf to an array of ints as there is no byte format specifier

--- a/src/test/kick_deep.script
+++ b/src/test/kick_deep.script
@@ -12,16 +12,16 @@ dawn min_kick_count=1
 
 
 #AP
-ap bssid=0A:7B:AA:00:01:00 ht_sup=1 vht_sup=1 util=156 stations=13 ssid=aTestSSID weight=10 neighbors=0A:7B:AA:00:01:00
-ap bssid=02:67:AA:00:02:00 ht_sup=1 vht_sup=1 util=195 stations=13 ssid=aTestSSID weight=10 neighbors=02:67:AA:00:02:00
-ap bssid=14:02:AA:00:03:00 ht_sup=1 vht_sup=1 util=126 stations=9 ssid=aTestSSID weight=10 neighbors=14:02:AA:00:03:00
-ap bssid=1F:36:AA:00:04:00 ht_sup=0 vht_sup=0 util=120 stations=8 ssid=aTestSSID weight=10 neighbors=1F:36:AA:00:04:00
-ap bssid=69:E9:AA:00:05:00 ht_sup=0 vht_sup=0 util=44 stations=4 ssid=aTestSSID weight=10 neighbors=69:E9:AA:00:05:00
-ap bssid=6A:97:AA:00:06:00 ht_sup=0 vht_sup=0 util=110 stations=11 ssid=aTestSSID weight=10 neighbors=6A:97:AA:00:06:00
-ap bssid=45:63:AA:00:07:00 ht_sup=0 vht_sup=0 util=55 stations=5 ssid=aTestSSID weight=10 neighbors=45:63:AA:00:07:00
-ap bssid=07:1E:AA:00:08:00 ht_sup=1 vht_sup=1 util=88 stations=8 ssid=aTestSSID weight=10 neighbors=07:1E:AA:00:08:00
-ap bssid=45:A2:AA:00:09:00 ht_sup=0 vht_sup=0 util=120 stations=12 ssid=aTestSSID weight=10 neighbors=45:A2:AA:00:09:00
-ap bssid=4C:4D:AA:00:0A:00 ht_sup=1 vht_sup=1 util=195 stations=13 ssid=aTestSSID weight=10 neighbors=4C:4D:AA:00:0A:00
+ap bssid=0A:7B:AA:00:01:00 ht_sup=1 vht_sup=1 util=156 stations=13 ssid=aTestSSID weight=10 neighbors=0A7BAA000100
+ap bssid=02:67:AA:00:02:00 ht_sup=1 vht_sup=1 util=195 stations=13 ssid=aTestSSID weight=10 neighbors=0267AA000200
+ap bssid=14:02:AA:00:03:00 ht_sup=1 vht_sup=1 util=126 stations=9 ssid=aTestSSID weight=10 neighbors=1402AA000300
+ap bssid=1F:36:AA:00:04:00 ht_sup=0 vht_sup=0 util=120 stations=8 ssid=aTestSSID weight=10 neighbors=1F36AA000400
+ap bssid=69:E9:AA:00:05:00 ht_sup=0 vht_sup=0 util=44 stations=4 ssid=aTestSSID weight=10 neighbors=69E9AA000500
+ap bssid=6A:97:AA:00:06:00 ht_sup=0 vht_sup=0 util=110 stations=11 ssid=aTestSSID weight=10 neighbors=6A97AA000600
+ap bssid=45:63:AA:00:07:00 ht_sup=0 vht_sup=0 util=55 stations=5 ssid=aTestSSID weight=10 neighbors=4563AA000700
+ap bssid=07:1E:AA:00:08:00 ht_sup=1 vht_sup=1 util=88 stations=8 ssid=aTestSSID weight=10 neighbors=071EAA000800
+ap bssid=45:A2:AA:00:09:00 ht_sup=0 vht_sup=0 util=120 stations=12 ssid=aTestSSID weight=10 neighbors=45A2AA000900
+ap bssid=4C:4D:AA:00:0A:00 ht_sup=1 vht_sup=1 util=195 stations=13 ssid=aTestSSID weight=10 neighbors=4C4DAA000A00
 
 #Client
 client client=50:7B:DD:00:01:00 bssid=45:A2:AA:00:09:00 freq=2500 ht_cap=1 vht_cap=1

--- a/src/test/kick_deep.script
+++ b/src/test/kick_deep.script
@@ -8,7 +8,7 @@ dawn max_chan_util=0
 dawn ap_weight=4
 dawn rssi=32
 dawn low_rssi=0
-dawn min_kick_count=1
+dawn min_number_to_kick=1
 
 
 #AP

--- a/src/test/scale_test_A.script
+++ b/src/test/scale_test_A.script
@@ -12,16 +12,16 @@ dawn min_kick_count=1
 
 
 #AP
-ap bssid=0A:7B:AA:00:01:00 ht_sup=1 vht_sup=1 util=156 stations=13 ssid=aTestSSID weight=10 neighbors=0A:7B:AA:00:01:00
-ap bssid=02:67:AA:00:02:00 ht_sup=1 vht_sup=1 util=195 stations=13 ssid=aTestSSID weight=10 neighbors=02:67:AA:00:02:00
-ap bssid=14:02:AA:00:03:00 ht_sup=1 vht_sup=1 util=126 stations=9 ssid=aTestSSID weight=10 neighbors=14:02:AA:00:03:00
-ap bssid=1F:36:AA:00:04:00 ht_sup=0 vht_sup=0 util=120 stations=8 ssid=aTestSSID weight=10 neighbors=1F:36:AA:00:04:00
-ap bssid=69:E9:AA:00:05:00 ht_sup=0 vht_sup=0 util=44 stations=4 ssid=aTestSSID weight=10 neighbors=69:E9:AA:00:05:00
-ap bssid=6A:97:AA:00:06:00 ht_sup=0 vht_sup=0 util=110 stations=11 ssid=aTestSSID weight=10 neighbors=6A:97:AA:00:06:00
-ap bssid=45:63:AA:00:07:00 ht_sup=0 vht_sup=0 util=55 stations=5 ssid=aTestSSID weight=10 neighbors=45:63:AA:00:07:00
-ap bssid=07:1E:AA:00:08:00 ht_sup=1 vht_sup=1 util=88 stations=8 ssid=aTestSSID weight=10 neighbors=07:1E:AA:00:08:00
-ap bssid=45:A2:AA:00:09:00 ht_sup=0 vht_sup=0 util=120 stations=12 ssid=aTestSSID weight=10 neighbors=45:A2:AA:00:09:00
-ap bssid=4C:4D:AA:00:0A:00 ht_sup=1 vht_sup=1 util=195 stations=13 ssid=aTestSSID weight=10 neighbors=4C:4D:AA:00:0A:00
+ap bssid=0A:7B:AA:00:01:00 ht_sup=1 vht_sup=1 util=156 stations=13 ssid=aTestSSID weight=10 neighbors=0A7BAA000100
+ap bssid=02:67:AA:00:02:00 ht_sup=1 vht_sup=1 util=195 stations=13 ssid=aTestSSID weight=10 neighbors=0267AA000200
+ap bssid=14:02:AA:00:03:00 ht_sup=1 vht_sup=1 util=126 stations=9 ssid=aTestSSID weight=10 neighbors=1402AA000300
+ap bssid=1F:36:AA:00:04:00 ht_sup=0 vht_sup=0 util=120 stations=8 ssid=aTestSSID weight=10 neighbors=1F36AA000400
+ap bssid=69:E9:AA:00:05:00 ht_sup=0 vht_sup=0 util=44 stations=4 ssid=aTestSSID weight=10 neighbors=69E9AA000500
+ap bssid=6A:97:AA:00:06:00 ht_sup=0 vht_sup=0 util=110 stations=11 ssid=aTestSSID weight=10 neighbors=6A97AA000600
+ap bssid=45:63:AA:00:07:00 ht_sup=0 vht_sup=0 util=55 stations=5 ssid=aTestSSID weight=10 neighbors=4563AA000700
+ap bssid=07:1E:AA:00:08:00 ht_sup=1 vht_sup=1 util=88 stations=8 ssid=aTestSSID weight=10 neighbors=071EAA000800
+ap bssid=45:A2:AA:00:09:00 ht_sup=0 vht_sup=0 util=120 stations=12 ssid=aTestSSID weight=10 neighbors=45A2AA000900
+ap bssid=4C:4D:AA:00:0A:00 ht_sup=1 vht_sup=1 util=195 stations=13 ssid=aTestSSID weight=10 neighbors=4C4DAA000A00
 
 #Client
 client client=50:7B:DD:00:01:00 bssid=45:A2:AA:00:09:00 freq=2500 ht_cap=1 vht_cap=1

--- a/src/test/scale_test_A.script
+++ b/src/test/scale_test_A.script
@@ -8,7 +8,7 @@ dawn max_chan_util=0
 dawn ap_weight=4
 dawn rssi=32
 dawn low_rssi=0
-dawn min_kick_count=1
+dawn min_number_to_kick=1
 
 
 #AP

--- a/src/test/simple_kick.script
+++ b/src/test/simple_kick.script
@@ -1,5 +1,5 @@
 dawn default
-dawn min_kick_count=2
+dawn min_number_to_kick=2
 ap bssid=11:22:33:44:55:66 neighbors=112233445566
 ap bssid=22:33:44:55:66:77 neighbors=223344556677
 client bssid=11:22:33:44:55:66 client=ff:ee:dd:cc:bb:aa

--- a/src/test/simple_kick.script
+++ b/src/test/simple_kick.script
@@ -1,7 +1,7 @@
 dawn default
 dawn min_kick_count=2
-ap bssid=11:22:33:44:55:66 neighbors=11:22:33:44:55:66
-ap bssid=22:33:44:55:66:77 neighbors=22:33:44:55:66:77
+ap bssid=11:22:33:44:55:66 neighbors=112233445566
+ap bssid=22:33:44:55:66:77 neighbors=223344556677
 client bssid=11:22:33:44:55:66 client=ff:ee:dd:cc:bb:aa
 ap_show
 client_show

--- a/src/test/test_storage.c
+++ b/src/test/test_storage.c
@@ -11,7 +11,7 @@
 #include "test_storage.h"
 
 /*** Test Stub Functions - Called by SUT ***/
-void ubus_send_beacon_report(client *c, int id)
+void ubus_send_beacon_report(client *c, ap *a, int id)
 {
     printf("send_beacon_report() was called...\n");
 }
@@ -654,7 +654,6 @@ static int consume_actions(int argc, char* argv[], int harness_verbosity)
                     dawn_metric.chan_util_avg_period = 3;
                     dawn_metric.set_hostapd_nr = 1;
                     dawn_metric.kicking = 0;
-                    dawn_metric.op_class = 0;
                     dawn_metric.duration = 0;
                     dawn_metric.rrm_mode_mask = WLAN_RRM_CAPS_BEACON_REPORT_PASSIVE |
                                                 WLAN_RRM_CAPS_BEACON_REPORT_ACTIVE |
@@ -662,7 +661,6 @@ static int consume_actions(int argc, char* argv[], int harness_verbosity)
                     dawn_metric.rrm_mode_order[0] = WLAN_RRM_CAPS_BEACON_REPORT_PASSIVE;
                     dawn_metric.rrm_mode_order[1] = WLAN_RRM_CAPS_BEACON_REPORT_ACTIVE;
                     dawn_metric.rrm_mode_order[2] = WLAN_RRM_CAPS_BEACON_REPORT_TABLE;
-                    dawn_metric.scan_channel = 0;
                 }
                 else if (!strncmp(fn, "ap_weight=", 10)) load_int(&dawn_metric.ap_weight, fn + 10);
                 else if (!strncmp(fn, "ht_support=", 11)) load_int(&dawn_metric.ht_support, fn + 11);
@@ -692,10 +690,8 @@ static int consume_actions(int argc, char* argv[], int harness_verbosity)
                 else if (!strncmp(fn, "chan_util_avg_period=", 21)) load_int(&dawn_metric.chan_util_avg_period, fn + 21);
                 else if (!strncmp(fn, "set_hostapd_nr=", 15)) load_int(&dawn_metric.set_hostapd_nr, fn + 15);
                 else if (!strncmp(fn, "kicking=", 8)) load_int(&dawn_metric.kicking, fn + 8);
-                else if (!strncmp(fn, "op_class=", 9)) load_int(&dawn_metric.op_class, fn + 9);
                 else if (!strncmp(fn, "duration=", 9)) load_int(&dawn_metric.duration, fn + 9);
                 else if (!strncmp(fn, "rrm_mode=", 9)) dawn_metric.rrm_mode_mask = parse_rrm_mode(dawn_metric.rrm_mode_order, fn + 9);
-                else if (!strncmp(fn, "scan_channel=", 13)) load_int(&dawn_metric.scan_channel, fn + 13);
                 else {
                     printf("ERROR: Loading DAWN control metrics, but don't recognise assignment \"%s\"\n", fn);
                     ret = 1;

--- a/src/test/test_storage.c
+++ b/src/test/test_storage.c
@@ -301,6 +301,15 @@ static int load_int(int* v, char* s)
     return ret;
 }
 
+static int load_int_band(int* v, char* s);
+static int load_int_band(int* v, char* s)
+{
+  int ret = 0;
+  sscanf(s, "%" "d", v);
+  v[1] = v[0];
+  return ret;
+}
+
 static int load_string(size_t l, char* v, char* s);
 static int load_string(size_t l, char* v, char* s)
 {
@@ -631,20 +640,34 @@ static int consume_actions(int argc, char* argv[], int harness_verbosity)
 
                 if (!strcmp(fn, "default"))
                 {
-                    dawn_metric.ap_weight = 0; // Sum component
-                    dawn_metric.ht_support = 10; // Sum component
-                    dawn_metric.vht_support = 100; // Sum component
-                    dawn_metric.no_ht_support = 0; // Sum component
-                    dawn_metric.no_vht_support = 0; // Sum component
-                    dawn_metric.rssi = 10; // Sum component
-                    dawn_metric.low_rssi = -500; // Sum component
-                    dawn_metric.freq = 100; // Sum component
-                    dawn_metric.chan_util = 0; // Sum component
-                    dawn_metric.max_chan_util = -500; // Sum component
-                    dawn_metric.rssi_val = -60;
-                    dawn_metric.low_rssi_val = -80;
-                    dawn_metric.chan_util_val = 140;
-                    dawn_metric.max_chan_util_val = 170;
+                    dawn_metric.ap_weight[0] = 0; // Sum component
+                    dawn_metric.ap_weight[1] = 0; // Sum component
+                    dawn_metric.ht_support[0] = 10; // Sum component
+                    dawn_metric.ht_support[1] = 10; // Sum component
+                    dawn_metric.vht_support[0] = 100; // Sum component
+                    dawn_metric.vht_support[1] = 100; // Sum component
+                    dawn_metric.no_ht_support[0] = 0; // Sum component
+                    dawn_metric.no_ht_support[1] = 0; // Sum component
+                    dawn_metric.no_vht_support[0] = 0; // Sum component
+                    dawn_metric.no_vht_support[1] = 0; // Sum component
+                    dawn_metric.rssi[0] = 10; // Sum component
+                    dawn_metric.rssi[1] = 10; // Sum component
+                    dawn_metric.low_rssi[0] = -500; // Sum component
+                    dawn_metric.low_rssi[1] = -500; // Sum component
+                    dawn_metric.freq[0] = 0; // Sum component
+                    dawn_metric.freq[1] = 100; // Sum component
+                    dawn_metric.chan_util[0] = 0; // Sum component
+                    dawn_metric.chan_util[1] = 0; // Sum component
+                    dawn_metric.max_chan_util[0] = -500; // Sum component
+                    dawn_metric.max_chan_util[1] = -500; // Sum component
+                    dawn_metric.rssi_val[0] = -60;
+                    dawn_metric.rssi_val[1] = -60;
+                    dawn_metric.low_rssi_val[0] = -80;
+                    dawn_metric.low_rssi_val[1] = -80;
+                    dawn_metric.chan_util_val[0] = 140;
+                    dawn_metric.chan_util_val[1] = 140;
+                    dawn_metric.max_chan_util_val[0] = 170;
+                    dawn_metric.max_chan_util_val[1] = 170;
                     dawn_metric.min_probe_count = 2;
                     dawn_metric.bandwidth_threshold = 6;
                     dawn_metric.use_station_count = 1;
@@ -655,7 +678,7 @@ static int consume_actions(int argc, char* argv[], int harness_verbosity)
                     dawn_metric.deny_auth_reason = 1;
                     dawn_metric.deny_assoc_reason = 17;
                     dawn_metric.use_driver_recog = 1;
-                    dawn_metric.min_kick_count = 3;
+                    dawn_metric.min_number_to_kick = 3;
                     dawn_metric.chan_util_avg_period = 3;
                     dawn_metric.set_hostapd_nr = 1;
                     dawn_metric.kicking = 0;
@@ -667,20 +690,20 @@ static int consume_actions(int argc, char* argv[], int harness_verbosity)
                     dawn_metric.rrm_mode_order[1] = WLAN_RRM_CAPS_BEACON_REPORT_ACTIVE;
                     dawn_metric.rrm_mode_order[2] = WLAN_RRM_CAPS_BEACON_REPORT_TABLE;
                 }
-                else if (!strncmp(fn, "ap_weight=", 10)) load_int(&dawn_metric.ap_weight, fn + 10);
-                else if (!strncmp(fn, "ht_support=", 11)) load_int(&dawn_metric.ht_support, fn + 11);
-                else if (!strncmp(fn, "vht_support=", 12)) load_int(&dawn_metric.vht_support, fn + 12);
-                else if (!strncmp(fn, "no_ht_support=", 14)) load_int(&dawn_metric.no_ht_support, fn + 14);
-                else if (!strncmp(fn, "no_vht_support=", 15)) load_int(&dawn_metric.no_vht_support, fn + 15);
-                else if (!strncmp(fn, "rssi=", 5)) load_int(&dawn_metric.rssi, fn + 5);
-                else if (!strncmp(fn, "low_rssi=", 9)) load_int(&dawn_metric.low_rssi, fn + 9);
-                else if (!strncmp(fn, "freq=", 5)) load_int(&dawn_metric.freq, fn + 5);
-                else if (!strncmp(fn, "chan_util=", 10)) load_int(&dawn_metric.chan_util, fn + 10);
-                else if (!strncmp(fn, "max_chan_util=", 14)) load_int(&dawn_metric.max_chan_util, fn + 14);
-                else if (!strncmp(fn, "rssi_val=", 9)) load_int(&dawn_metric.rssi_val, fn + 9);
-                else if (!strncmp(fn, "low_rssi_val=", 13)) load_int(&dawn_metric.low_rssi_val, fn + 13);
-                else if (!strncmp(fn, "chan_util_val=", 14)) load_int(&dawn_metric.chan_util_val, fn + 14);
-                else if (!strncmp(fn, "max_chan_util_val=", 18)) load_int(&dawn_metric.max_chan_util_val, fn + 18);
+                else if (!strncmp(fn, "ap_weight=", 10)) load_int_band(dawn_metric.ap_weight, fn + 10);
+                else if (!strncmp(fn, "ht_support=", 11)) load_int_band(dawn_metric.ht_support, fn + 11);
+                else if (!strncmp(fn, "vht_support=", 12)) load_int_band(dawn_metric.vht_support, fn + 12);
+                else if (!strncmp(fn, "no_ht_support=", 14)) load_int_band(dawn_metric.no_ht_support, fn + 14);
+                else if (!strncmp(fn, "no_vht_support=", 15)) load_int_band(dawn_metric.no_vht_support, fn + 15);
+                else if (!strncmp(fn, "rssi=", 5)) load_int_band(dawn_metric.rssi, fn + 5);
+                else if (!strncmp(fn, "low_rssi=", 9)) load_int_band(dawn_metric.low_rssi, fn + 9);
+                else if (!strncmp(fn, "freq=", 5)) load_int(&dawn_metric.freq[1], fn + 5);
+                else if (!strncmp(fn, "chan_util=", 10)) load_int_band(dawn_metric.chan_util, fn + 10);
+                else if (!strncmp(fn, "max_chan_util=", 14)) load_int_band(dawn_metric.max_chan_util, fn + 14);
+                else if (!strncmp(fn, "rssi_val=", 9)) load_int_band(dawn_metric.rssi_val, fn + 9);
+                else if (!strncmp(fn, "low_rssi_val=", 13)) load_int_band(dawn_metric.low_rssi_val, fn + 13);
+                else if (!strncmp(fn, "chan_util_val=", 14)) load_int_band(dawn_metric.chan_util_val, fn + 14);
+                else if (!strncmp(fn, "max_chan_util_val=", 18)) load_int_band(dawn_metric.max_chan_util_val, fn + 18);
                 else if (!strncmp(fn, "min_probe_count=", 16)) load_int(&dawn_metric.min_probe_count, fn + 16);
                 else if (!strncmp(fn, "bandwidth_threshold=", 20)) load_int(&dawn_metric.bandwidth_threshold, fn + 20);
                 else if (!strncmp(fn, "use_station_count=", 18)) load_int(&dawn_metric.use_station_count, fn + 18);
@@ -691,7 +714,7 @@ static int consume_actions(int argc, char* argv[], int harness_verbosity)
                 else if (!strncmp(fn, "deny_auth_reason=", 17)) load_int(&dawn_metric.deny_auth_reason, fn + 17);
                 else if (!strncmp(fn, "deny_assoc_reason=", 18)) load_int(&dawn_metric.deny_assoc_reason, fn + 18);
                 else if (!strncmp(fn, "use_driver_recog=", 17)) load_int(&dawn_metric.use_driver_recog, fn + 17);
-                else if (!strncmp(fn, "min_kick_count=", 15)) load_int(&dawn_metric.min_kick_count, fn + 15);
+                else if (!strncmp(fn, "min_number_to_kick=", 19)) load_int(&dawn_metric.min_number_to_kick, fn + 19);
                 else if (!strncmp(fn, "chan_util_avg_period=", 21)) load_int(&dawn_metric.chan_util_avg_period, fn + 21);
                 else if (!strncmp(fn, "set_hostapd_nr=", 15)) load_int(&dawn_metric.set_hostapd_nr, fn + 15);
                 else if (!strncmp(fn, "kicking=", 8)) load_int(&dawn_metric.kicking, fn + 8);

--- a/src/test/test_storage.c
+++ b/src/test/test_storage.c
@@ -654,8 +654,8 @@ static int consume_actions(int argc, char* argv[], int harness_verbosity)
                     dawn_metric.rssi[1] = 10; // Sum component
                     dawn_metric.low_rssi[0] = -500; // Sum component
                     dawn_metric.low_rssi[1] = -500; // Sum component
-                    dawn_metric.freq[0] = 0; // Sum component
-                    dawn_metric.freq[1] = 100; // Sum component
+                    dawn_metric.initial_score[0] = 0; // Sum component
+                    dawn_metric.initial_score[1] = 100; // Sum component
                     dawn_metric.chan_util[0] = 0; // Sum component
                     dawn_metric.chan_util[1] = 0; // Sum component
                     dawn_metric.max_chan_util[0] = -500; // Sum component
@@ -697,7 +697,7 @@ static int consume_actions(int argc, char* argv[], int harness_verbosity)
                 else if (!strncmp(fn, "no_vht_support=", 15)) load_int_band(dawn_metric.no_vht_support, fn + 15);
                 else if (!strncmp(fn, "rssi=", 5)) load_int_band(dawn_metric.rssi, fn + 5);
                 else if (!strncmp(fn, "low_rssi=", 9)) load_int_band(dawn_metric.low_rssi, fn + 9);
-                else if (!strncmp(fn, "freq=", 5)) load_int(&dawn_metric.freq[1], fn + 5);
+                else if (!strncmp(fn, "freq=", 5)) load_int(&dawn_metric.initial_score[1], fn + 5);
                 else if (!strncmp(fn, "chan_util=", 10)) load_int_band(dawn_metric.chan_util, fn + 10);
                 else if (!strncmp(fn, "max_chan_util=", 14)) load_int_band(dawn_metric.max_chan_util, fn + 14);
                 else if (!strncmp(fn, "rssi_val=", 9)) load_int_band(dawn_metric.rssi_val, fn + 9);

--- a/src/utils/dawn_iwinfo.c
+++ b/src/utils/dawn_iwinfo.c
@@ -72,10 +72,6 @@ int compare_essid_iwinfo(struct dawn_mac bssid_addr, struct dawn_mac bssid_addr_
     }
     closedir(dirp);
 
-#ifndef DAWN_NO_OUTPUT
-    printf("Comparing: %s with %s\n", essid, essid_to_compare);
-#endif
-
     if (essid == NULL || essid_to_compare == NULL) {
         return -1;
     }
@@ -122,15 +118,9 @@ int get_bandwidth(const char *ifname, struct dawn_mac client_addr, float *rx_rat
     iw = iwinfo_backend(ifname);
 
     if (iw->assoclist(ifname, buf, &len)) {
-#ifndef DAWN_NO_OUTPUT
-        fprintf(stdout, "No information available\n");
-#endif
         iwinfo_finish();
         return 0;
     } else if (len <= 0) {
-#ifndef DAWN_NO_OUTPUT
-        fprintf(stdout, "No station connected\n");
-#endif
         iwinfo_finish();
         return 0;
     }
@@ -362,9 +352,6 @@ int support_ht(const char *ifname) {
 
     if (iw->htmodelist(ifname, &htmodes))
     {
-#ifndef DAWN_NO_OUTPUT
-        printf("No HT mode information available\n");
-#endif
         iwinfo_finish();
         return 0;
     }
@@ -384,7 +371,6 @@ int support_vht(const char *ifname) {
 
     if (iw->htmodelist(ifname, &htmodes))
     {
-        fprintf(stderr, "No VHT mode information available\n");
         iwinfo_finish();
         return 0;
     }

--- a/src/utils/dawn_iwinfo.c
+++ b/src/utils/dawn_iwinfo.c
@@ -72,7 +72,9 @@ int compare_essid_iwinfo(struct dawn_mac bssid_addr, struct dawn_mac bssid_addr_
     }
     closedir(dirp);
 
+#ifndef DAWN_NO_OUTPUT
     printf("Comparing: %s with %s\n", essid, essid_to_compare);
+#endif
 
     if (essid == NULL || essid_to_compare == NULL) {
         return -1;
@@ -120,11 +122,15 @@ int get_bandwidth(const char *ifname, struct dawn_mac client_addr, float *rx_rat
     iw = iwinfo_backend(ifname);
 
     if (iw->assoclist(ifname, buf, &len)) {
+#ifndef DAWN_NO_OUTPUT
         fprintf(stdout, "No information available\n");
+#endif
         iwinfo_finish();
         return 0;
     } else if (len <= 0) {
+#ifndef DAWN_NO_OUTPUT
         fprintf(stdout, "No station connected\n");
+#endif
         iwinfo_finish();
         return 0;
     }
@@ -177,11 +183,15 @@ int get_rssi(const char *ifname, struct dawn_mac client_addr) {
     iw = iwinfo_backend(ifname);
 
     if (iw->assoclist(ifname, buf, &len)) {
+#ifndef DAWN_NO_OUTPUT
         fprintf(stdout, "No information available\n");
+#endif
         iwinfo_finish();
         return INT_MIN;
     } else if (len <= 0) {
+#ifndef DAWN_NO_OUTPUT
         fprintf(stdout, "No station connected\n");
+#endif
         iwinfo_finish();
         return INT_MIN;
     }
@@ -233,11 +243,15 @@ int get_expected_throughput(const char *ifname, struct dawn_mac client_addr) {
     iw = iwinfo_backend(ifname);
 
     if (iw->assoclist(ifname, buf, &len)) {
+#ifndef DAWN_NO_OUTPUT
         fprintf(stdout, "No information available\n");
+#endif
         iwinfo_finish();
         return INT_MIN;
     } else if (len <= 0) {
+#ifndef DAWN_NO_OUTPUT
         fprintf(stdout, "No station connected\n");
+#endif
         iwinfo_finish();
         return INT_MIN;
     }
@@ -348,7 +362,9 @@ int support_ht(const char *ifname) {
 
     if (iw->htmodelist(ifname, &htmodes))
     {
+#ifndef DAWN_NO_OUTPUT
         printf("No HT mode information available\n");
+#endif
         iwinfo_finish();
         return 0;
     }

--- a/src/utils/dawn_uci.c
+++ b/src/utils/dawn_uci.c
@@ -153,11 +153,9 @@ struct probe_metric_s uci_get_dawn_metric() {
             ret.min_kick_count = uci_lookup_option_int(uci_ctx, s, "min_number_to_kick");
             ret.chan_util_avg_period = uci_lookup_option_int(uci_ctx, s, "chan_util_avg_period");
             ret.set_hostapd_nr = uci_lookup_option_int(uci_ctx, s, "set_hostapd_nr");
-            ret.op_class = uci_lookup_option_int(uci_ctx, s, "op_class");
             ret.duration = uci_lookup_option_int(uci_ctx, s, "duration");
             ret.rrm_mode_mask = parse_rrm_mode(ret.rrm_mode_order,
                                                uci_lookup_option_string(uci_ctx, s, "rrm_mode"));
-            ret.scan_channel = uci_lookup_option_int(uci_ctx, s, "scan_channel");
             return ret;
         }
     }

--- a/src/utils/dawn_uci.c
+++ b/src/utils/dawn_uci.c
@@ -244,7 +244,7 @@ struct probe_metric_s uci_get_dawn_metric() {
         .no_vht_support = { 0, 0 },
         .rssi = { 10, 10 },
         .rssi_val = { -60, -60 },
-        .freq = { 0, 100 },
+        .initial_score = { 0, 100 },
         .chan_util = { 0, 0 },
         .max_chan_util = { -500, -500 },
         .chan_util_val = { 140, 140 },
@@ -267,6 +267,7 @@ struct probe_metric_s uci_get_dawn_metric() {
     if (global_s) {
         // True global configuration
         DAWN_SET_CONFIG_INT(ret, global_s, kicking);
+        DAWN_SET_CONFIG_INT(ret, global_s, kicking_threshold);
         DAWN_SET_CONFIG_INT(ret, global_s, min_probe_count);
         DAWN_SET_CONFIG_INT(ret, global_s, use_station_count);
         DAWN_SET_CONFIG_INT(ret, global_s, eval_auth_req);
@@ -291,6 +292,7 @@ struct probe_metric_s uci_get_dawn_metric() {
         ret.neighbors[band] = uci_lookup_mac_list(neighbors ? : global_neighbors);
     }
 
+    DAWN_SET_BANDS_CONFIG_INT(ret, global_s, band_s, initial_score);
     DAWN_SET_BANDS_CONFIG_INT(ret, global_s, band_s, ap_weight);
     DAWN_SET_BANDS_CONFIG_INT(ret, global_s, band_s, ht_support);
     DAWN_SET_BANDS_CONFIG_INT(ret, global_s, band_s, vht_support);
@@ -298,13 +300,14 @@ struct probe_metric_s uci_get_dawn_metric() {
     DAWN_SET_BANDS_CONFIG_INT(ret, global_s, band_s, no_vht_support);
     DAWN_SET_BANDS_CONFIG_INT(ret, global_s, band_s, rssi);
     DAWN_SET_BANDS_CONFIG_INT(ret, global_s, band_s, rssi_val);
-    DAWN_SET_BANDS_CONFIG_INT(ret, global_s, band_s, freq);
     DAWN_SET_BANDS_CONFIG_INT(ret, global_s, band_s, chan_util);
     DAWN_SET_BANDS_CONFIG_INT(ret, global_s, band_s, max_chan_util);
     DAWN_SET_BANDS_CONFIG_INT(ret, global_s, band_s, chan_util_val);
     DAWN_SET_BANDS_CONFIG_INT(ret, global_s, band_s, max_chan_util_val);
     DAWN_SET_BANDS_CONFIG_INT(ret, global_s, band_s, low_rssi);
     DAWN_SET_BANDS_CONFIG_INT(ret, global_s, band_s, low_rssi_val);
+    DAWN_SET_BANDS_CONFIG_INT(ret, global_s, band_s, rssi_weight);
+    DAWN_SET_BANDS_CONFIG_INT(ret, global_s, band_s, rssi_center);
     return ret;
 }
 

--- a/src/utils/msghandler.c
+++ b/src/utils/msghandler.c
@@ -519,8 +519,10 @@ int parse_to_clients(struct blob_attr* msg, int do_kick, uint32_t id) {
         }
 
 
+        ap_entry->op_class = ap_entry->channel = 0;
         if (tb[CLIENT_TABLE_NEIGHBOR]) {
             strncpy(ap_entry->neighbor_report, blobmsg_get_string(tb[CLIENT_TABLE_NEIGHBOR]), NEIGHBOR_REPORT_LEN);
+            sscanf(ap_entry->neighbor_report + NR_OP_CLASS, "%2x%2x", &ap_entry->op_class, &ap_entry->channel);
         }
         else {
             ap_entry->neighbor_report[0] = '\0';
@@ -584,10 +586,8 @@ enum {
     UCI_MIN_NUMBER_TO_KICK,
     UCI_CHAN_UTIL_AVG_PERIOD,
     UCI_SET_HOSTAPD_NR,
-    UCI_OP_CLASS,
     UCI_DURATION,
     UCI_RRM_MODE,
-    UCI_SCAN_CHANNEL,
     __UCI_METIC_MAX
 };
 
@@ -637,10 +637,8 @@ static const struct blobmsg_policy uci_metric_policy[__UCI_METIC_MAX] = {
         [UCI_MIN_NUMBER_TO_KICK] = {.name = "min_number_to_kick", .type = BLOBMSG_TYPE_INT32},
         [UCI_CHAN_UTIL_AVG_PERIOD] = {.name = "chan_util_avg_period", .type = BLOBMSG_TYPE_INT32},
         [UCI_SET_HOSTAPD_NR] = {.name = "set_hostapd_nr", .type = BLOBMSG_TYPE_INT32},
-        [UCI_OP_CLASS] = {.name = "op_class", .type = BLOBMSG_TYPE_INT32},
         [UCI_DURATION] = {.name = "duration", .type = BLOBMSG_TYPE_INT32},
         [UCI_RRM_MODE] = {.name = "rrm_mode", .type = BLOBMSG_TYPE_STRING},
-        [UCI_SCAN_CHANNEL] = {.name = "scan_channel", .type = BLOBMSG_TYPE_INT32},
 };
 
 static const struct blobmsg_policy uci_times_policy[__UCI_TIMES_MAX] = {
@@ -746,16 +744,10 @@ static int handle_uci_config(struct blob_attr* msg) {
     sprintf(cmd_buffer, "dawn.@metric[0].set_hostapd_nr=%d", blobmsg_get_u32(tb_metric[UCI_SET_HOSTAPD_NR]));
     uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].op_class=%d", blobmsg_get_u32(tb_metric[UCI_OP_CLASS]));
-    uci_set_network(cmd_buffer);
-
     sprintf(cmd_buffer, "dawn.@metric[0].duration=%d", blobmsg_get_u32(tb_metric[UCI_DURATION]));
     uci_set_network(cmd_buffer);
 
     sprintf(cmd_buffer, "dawn.@metric[0].rrm_mode=%s", blobmsg_get_string(tb_metric[UCI_RRM_MODE]));
-    uci_set_network(cmd_buffer);
-
-    sprintf(cmd_buffer, "dawn.@metric[0].scan_channel=%d", blobmsg_get_u32(tb_metric[UCI_SCAN_CHANNEL]));
     uci_set_network(cmd_buffer);
 
     struct blob_attr* tb_times[__UCI_TIMES_MAX];

--- a/src/utils/msghandler.c
+++ b/src/utils/msghandler.c
@@ -228,10 +228,6 @@ int handle_deauth_req(struct blob_attr* msg) {
 
     pthread_mutex_unlock(&client_array_mutex);
 
-#ifndef DAWN_NO_OUTPUT
-    printf("[WC] Deauth: %s\n", "deauth");
-#endif
-
     return 0;
 }
 

--- a/src/utils/msghandler.c
+++ b/src/utils/msghandler.c
@@ -580,6 +580,7 @@ enum {
     UCI_EVAL_AUTH_REQ,
     UCI_EVAL_ASSOC_REQ,
     UCI_KICKING,
+    UCI_KICKING_THRESHOLD,
     UCI_DENY_AUTH_REASON,
     UCI_DENY_ASSOC_REASON,
     UCI_USE_DRIVER_RECOG,
@@ -594,7 +595,7 @@ enum {
 
 enum {
     UCI_BAND,
-    UCI_FREQ,
+    UCI_INITIAL_SCORE,
     UCI_AP_WEIGHT,
     UCI_HT_SUPPORT,
     UCI_VHT_SUPPORT,
@@ -608,6 +609,8 @@ enum {
     UCI_LOW_RSSI_VAL,
     UCI_CHAN_UTIL_VAL,
     UCI_MAX_CHAN_UTIL_VAL,
+    UCI_RSSI_WEIGHT,
+    UCI_RSSI_CENTER,
     __UCI_BAND_METRIC_MAX
 };
 
@@ -639,6 +642,7 @@ static const struct blobmsg_policy uci_metric_policy[__UCI_METRIC_MAX] = {
         [UCI_EVAL_AUTH_REQ] = {.name = "eval_auth_req", .type = BLOBMSG_TYPE_INT32},
         [UCI_EVAL_ASSOC_REQ] = {.name = "eval_assoc_req", .type = BLOBMSG_TYPE_INT32},
         [UCI_KICKING] = {.name = "kicking", .type = BLOBMSG_TYPE_INT32},
+        [UCI_KICKING_THRESHOLD] = {.name = "kicking_threshold", .type = BLOBMSG_TYPE_INT32},
         [UCI_DENY_AUTH_REASON] = {.name = "deny_auth_reason", .type = BLOBMSG_TYPE_INT32},
         [UCI_DENY_ASSOC_REASON] = {.name = "deny_assoc_reason", .type = BLOBMSG_TYPE_INT32},
         [UCI_USE_DRIVER_RECOG] = {.name = "use_driver_recog", .type = BLOBMSG_TYPE_INT32},
@@ -651,7 +655,7 @@ static const struct blobmsg_policy uci_metric_policy[__UCI_METRIC_MAX] = {
 };
 
 static const struct blobmsg_policy uci_band_metric_policy[__UCI_METRIC_MAX] = {
-        [UCI_FREQ] = {.name = "freq", .type = BLOBMSG_TYPE_INT32},
+        [UCI_INITIAL_SCORE] = {.name = "initial_score", .type = BLOBMSG_TYPE_INT32},
         [UCI_HT_SUPPORT] = {.name = "ht_support", .type = BLOBMSG_TYPE_INT32},
         [UCI_VHT_SUPPORT] = {.name = "vht_support", .type = BLOBMSG_TYPE_INT32},
         [UCI_NO_HT_SUPPORT] = {.name = "no_ht_support", .type = BLOBMSG_TYPE_INT32},
@@ -664,6 +668,8 @@ static const struct blobmsg_policy uci_band_metric_policy[__UCI_METRIC_MAX] = {
         [UCI_MAX_CHAN_UTIL] = {.name = "max_chan_util", .type = BLOBMSG_TYPE_INT32},
         [UCI_CHAN_UTIL_VAL] = {.name = "chan_util_val", .type = BLOBMSG_TYPE_INT32},
         [UCI_MAX_CHAN_UTIL_VAL] = {.name = "max_chan_util_val", .type = BLOBMSG_TYPE_INT32},
+        [UCI_RSSI_WEIGHT] = {.name = "rssi_weight", .type = BLOBMSG_TYPE_INT32},
+        [UCI_RSSI_CENTER] = {.name = "rssi_center", .type = BLOBMSG_TYPE_INT32},
 };
 
 static const struct blobmsg_policy uci_times_policy[__UCI_TIMES_MAX] = {
@@ -723,6 +729,9 @@ static int handle_uci_config(struct blob_attr* msg) {
     sprintf(cmd_buffer, "dawn.global.kicking=%d", blobmsg_get_u32(tb_metric[UCI_KICKING]));
     uci_set_network(cmd_buffer);
 
+    sprintf(cmd_buffer, "dawn.global.kicking_threshold=%d", blobmsg_get_u32(tb_metric[UCI_KICKING_THRESHOLD]));
+    uci_set_network(cmd_buffer);
+
     sprintf(cmd_buffer, "dawn.global.deny_auth_reason=%d", blobmsg_get_u32(tb_metric[UCI_DENY_AUTH_REASON]));
     uci_set_network(cmd_buffer);
 
@@ -770,7 +779,7 @@ static int handle_uci_config(struct blob_attr* msg) {
         sprintf(cmd_buffer, "dawn.%s=metric", band_name);
         uci_set_network(cmd_buffer);
 
-        sprintf(cmd_buffer, "dawn.%s.freq=%d", band_name, blobmsg_get_u32(tb_band_metric[UCI_FREQ]));
+        sprintf(cmd_buffer, "dawn.%s.initial_score=%d", band_name, blobmsg_get_u32(tb_band_metric[UCI_INITIAL_SCORE]));
         uci_set_network(cmd_buffer);
 
         sprintf(cmd_buffer, "dawn.%s.ht_support=%d", band_name, blobmsg_get_u32(tb_band_metric[UCI_HT_SUPPORT]));
@@ -807,6 +816,12 @@ static int handle_uci_config(struct blob_attr* msg) {
         uci_set_network(cmd_buffer);
 
         sprintf(cmd_buffer, "dawn.%s.max_chan_util_val=%d", band_name, blobmsg_get_u32(tb_band_metric[UCI_MAX_CHAN_UTIL_VAL]));
+        uci_set_network(cmd_buffer);
+
+        sprintf(cmd_buffer, "dawn.%s.rssi_weight=%d", band_name, blobmsg_get_u32(tb_band_metric[UCI_RSSI_WEIGHT]));
+        uci_set_network(cmd_buffer);
+
+        sprintf(cmd_buffer, "dawn.%s.rssi_center=%d", band_name, blobmsg_get_u32(tb_band_metric[UCI_RSSI_CENTER]));
         uci_set_network(cmd_buffer);
     }
 

--- a/src/utils/msghandler.c
+++ b/src/utils/msghandler.c
@@ -553,6 +553,7 @@ int parse_to_clients(struct blob_attr* msg, int do_kick, uint32_t id) {
 }
 
 enum {
+    UCI_CONFIG_VERSION,
     UCI_TABLE_METRIC,
     UCI_TABLE_TIMES,
     __UCI_TABLE_MAX
@@ -605,6 +606,7 @@ enum {
 };
 
 static const struct blobmsg_policy uci_table_policy[__UCI_TABLE_MAX] = {
+        [UCI_CONFIG_VERSION ] = {.name = "version", .type = BLOBMSG_TYPE_STRING},
         [UCI_TABLE_METRIC] = {.name = "metric", .type = BLOBMSG_TYPE_TABLE},
         [UCI_TABLE_TIMES] = {.name = "times", .type = BLOBMSG_TYPE_TABLE}
 };
@@ -657,6 +659,13 @@ static int handle_uci_config(struct blob_attr* msg) {
 
     struct blob_attr* tb[__UCI_TABLE_MAX];
     blobmsg_parse(uci_table_policy, __UCI_TABLE_MAX, tb, blob_data(msg), blob_len(msg));
+
+    const char *version_string = blobmsg_get_string(tb[UCI_CONFIG_VERSION]);
+    if (version_string == NULL || strcmp(version_string, DAWN_CONFIG_VERSION)) {
+        fprintf(stderr, "Ignoring network config message with incompatible version string '%s'.\n",
+                version_string ? : "");
+        return -1;
+    }
 
     struct blob_attr* tb_metric[__UCI_METIC_MAX];
     blobmsg_parse(uci_metric_policy, __UCI_METIC_MAX, tb_metric, blobmsg_data(tb[UCI_TABLE_METRIC]), blobmsg_len(tb[UCI_TABLE_METRIC]));

--- a/src/utils/msghandler.c
+++ b/src/utils/msghandler.c
@@ -228,7 +228,9 @@ int handle_deauth_req(struct blob_attr* msg) {
 
     pthread_mutex_unlock(&client_array_mutex);
 
+#ifndef DAWN_NO_OUTPUT
     printf("[WC] Deauth: %s\n", "deauth");
+#endif
 
     return 0;
 }
@@ -260,7 +262,9 @@ int handle_network_msg(char* msg) {
     method = blobmsg_data(tb[NETWORK_METHOD]);
     data = blobmsg_data(tb[NETWORK_DATA]);
 
+#ifndef DAWN_NO_OUTPUT
     printf("Network Method new: %s : %s\n", method, msg);
+#endif
 
     blob_buf_init(&data_buf, 0);
     blobmsg_add_json_from_string(&data_buf, data);
@@ -294,11 +298,15 @@ int handle_network_msg(char* msg) {
         parse_to_clients(data_buf.head, 0, 0);
     }
     else if (strncmp(method, "deauth", 5) == 0) {
+#ifndef DAWN_NO_OUTPUT
         printf("METHOD DEAUTH\n");
+#endif
         handle_deauth_req(data_buf.head);
     }
     else if (strncmp(method, "setprobe", 5) == 0) {
+#ifndef DAWN_NO_OUTPUT
         printf("HANDLING SET PROBE!\n");
+#endif
         handle_set_probe(data_buf.head);
     }
     else if (strncmp(method, "addmac", 5) == 0) {
@@ -308,7 +316,9 @@ int handle_network_msg(char* msg) {
         parse_add_mac_to_file(data_buf.head);
     }
     else if (strncmp(method, "uci", 2) == 0) {
+#ifndef DAWN_NO_OUTPUT
         printf("HANDLING UCI!\n");
+#endif
         handle_uci_config(data_buf.head);
     }
     else if (strncmp(method, "beacon-report", 12) == 0) {
@@ -322,7 +332,9 @@ int handle_network_msg(char* msg) {
     }
     else
     {
+#ifndef DAWN_NO_OUTPUT
         printf("No method fonud for: %s\n", method);
+#endif
     }
 
     return 0;

--- a/src/utils/msghandler.c
+++ b/src/utils/msghandler.c
@@ -560,19 +560,6 @@ enum {
 };
 
 enum {
-    UCI_HT_SUPPORT,
-    UCI_VHT_SUPPORT,
-    UCI_NO_HT_SUPPORT,
-    UCI_NO_VHT_SUPPORT,
-    UCI_RSSI,
-    UCI_LOW_RSSI,
-    UCI_FREQ,
-    UCI_CHAN_UTIL,
-    UCI_MAX_CHAN_UTIL,
-    UCI_RSSI_VAL,
-    UCI_LOW_RSSI_VAL,
-    UCI_CHAN_UTIL_VAL,
-    UCI_MAX_CHAN_UTIL_VAL,
     UCI_MIN_PROBE_COUNT,
     UCI_BANDWIDTH_THRESHOLD,
     UCI_USE_STATION_COUNT,
@@ -589,7 +576,27 @@ enum {
     UCI_SET_HOSTAPD_NR,
     UCI_DURATION,
     UCI_RRM_MODE,
-    __UCI_METIC_MAX
+    UCI_BAND_METRICS,
+    __UCI_METRIC_MAX
+};
+
+enum {
+    UCI_BAND,
+    UCI_FREQ,
+    UCI_AP_WEIGHT,
+    UCI_HT_SUPPORT,
+    UCI_VHT_SUPPORT,
+    UCI_NO_HT_SUPPORT,
+    UCI_NO_VHT_SUPPORT,
+    UCI_RSSI,
+    UCI_LOW_RSSI,
+    UCI_CHAN_UTIL,
+    UCI_MAX_CHAN_UTIL,
+    UCI_RSSI_VAL,
+    UCI_LOW_RSSI_VAL,
+    UCI_CHAN_UTIL_VAL,
+    UCI_MAX_CHAN_UTIL_VAL,
+    __UCI_BAND_METRIC_MAX
 };
 
 enum {
@@ -611,20 +618,7 @@ static const struct blobmsg_policy uci_table_policy[__UCI_TABLE_MAX] = {
         [UCI_TABLE_TIMES] = {.name = "times", .type = BLOBMSG_TYPE_TABLE}
 };
 
-static const struct blobmsg_policy uci_metric_policy[__UCI_METIC_MAX] = {
-        [UCI_HT_SUPPORT] = {.name = "ht_support", .type = BLOBMSG_TYPE_INT32},
-        [UCI_VHT_SUPPORT] = {.name = "vht_support", .type = BLOBMSG_TYPE_INT32},
-        [UCI_NO_HT_SUPPORT] = {.name = "no_ht_support", .type = BLOBMSG_TYPE_INT32},
-        [UCI_NO_VHT_SUPPORT] = {.name = "no_vht_support", .type = BLOBMSG_TYPE_INT32},
-        [UCI_RSSI] = {.name = "rssi", .type = BLOBMSG_TYPE_INT32},
-        [UCI_LOW_RSSI] = {.name = "low_rssi", .type = BLOBMSG_TYPE_INT32},
-        [UCI_FREQ] = {.name = "freq", .type = BLOBMSG_TYPE_INT32},
-        [UCI_CHAN_UTIL] = {.name = "chan_util", .type = BLOBMSG_TYPE_INT32},
-        [UCI_MAX_CHAN_UTIL] = {.name = "max_chan_util", .type = BLOBMSG_TYPE_INT32},
-        [UCI_RSSI_VAL] = {.name = "rssi_val", .type = BLOBMSG_TYPE_INT32},
-        [UCI_LOW_RSSI_VAL] = {.name = "low_rssi_val", .type = BLOBMSG_TYPE_INT32},
-        [UCI_CHAN_UTIL_VAL] = {.name = "chan_util_val", .type = BLOBMSG_TYPE_INT32},
-        [UCI_MAX_CHAN_UTIL_VAL] = {.name = "max_chan_util_val", .type = BLOBMSG_TYPE_INT32},
+static const struct blobmsg_policy uci_metric_policy[__UCI_METRIC_MAX] = {
         [UCI_MIN_PROBE_COUNT] = {.name = "min_probe_count", .type = BLOBMSG_TYPE_INT32},
         [UCI_BANDWIDTH_THRESHOLD] = {.name = "bandwidth_threshold", .type = BLOBMSG_TYPE_INT32},
         [UCI_USE_STATION_COUNT] = {.name = "use_station_count", .type = BLOBMSG_TYPE_INT32},
@@ -641,6 +635,23 @@ static const struct blobmsg_policy uci_metric_policy[__UCI_METIC_MAX] = {
         [UCI_SET_HOSTAPD_NR] = {.name = "set_hostapd_nr", .type = BLOBMSG_TYPE_INT32},
         [UCI_DURATION] = {.name = "duration", .type = BLOBMSG_TYPE_INT32},
         [UCI_RRM_MODE] = {.name = "rrm_mode", .type = BLOBMSG_TYPE_STRING},
+        [UCI_BAND_METRICS] = {.name = "band_metrics", .type = BLOBMSG_TYPE_TABLE},
+};
+
+static const struct blobmsg_policy uci_band_metric_policy[__UCI_METRIC_MAX] = {
+        [UCI_FREQ] = {.name = "freq", .type = BLOBMSG_TYPE_INT32},
+        [UCI_HT_SUPPORT] = {.name = "ht_support", .type = BLOBMSG_TYPE_INT32},
+        [UCI_VHT_SUPPORT] = {.name = "vht_support", .type = BLOBMSG_TYPE_INT32},
+        [UCI_NO_HT_SUPPORT] = {.name = "no_ht_support", .type = BLOBMSG_TYPE_INT32},
+        [UCI_NO_VHT_SUPPORT] = {.name = "no_vht_support", .type = BLOBMSG_TYPE_INT32},
+        [UCI_RSSI] = {.name = "rssi", .type = BLOBMSG_TYPE_INT32},
+        [UCI_RSSI_VAL] = {.name = "rssi_val", .type = BLOBMSG_TYPE_INT32},
+        [UCI_LOW_RSSI] = {.name = "low_rssi", .type = BLOBMSG_TYPE_INT32},
+        [UCI_LOW_RSSI_VAL] = {.name = "low_rssi_val", .type = BLOBMSG_TYPE_INT32},
+        [UCI_CHAN_UTIL] = {.name = "chan_util", .type = BLOBMSG_TYPE_INT32},
+        [UCI_MAX_CHAN_UTIL] = {.name = "max_chan_util", .type = BLOBMSG_TYPE_INT32},
+        [UCI_CHAN_UTIL_VAL] = {.name = "chan_util_val", .type = BLOBMSG_TYPE_INT32},
+        [UCI_MAX_CHAN_UTIL_VAL] = {.name = "max_chan_util_val", .type = BLOBMSG_TYPE_INT32},
 };
 
 static const struct blobmsg_policy uci_times_policy[__UCI_TIMES_MAX] = {
@@ -667,97 +678,125 @@ static int handle_uci_config(struct blob_attr* msg) {
         return -1;
     }
 
-    struct blob_attr* tb_metric[__UCI_METIC_MAX];
-    blobmsg_parse(uci_metric_policy, __UCI_METIC_MAX, tb_metric, blobmsg_data(tb[UCI_TABLE_METRIC]), blobmsg_len(tb[UCI_TABLE_METRIC]));
+    struct blob_attr* tb_metric[__UCI_METRIC_MAX];
+    blobmsg_parse(uci_metric_policy, __UCI_METRIC_MAX, tb_metric, blobmsg_data(tb[UCI_TABLE_METRIC]), blobmsg_len(tb[UCI_TABLE_METRIC]));
 
     // TODO: Magic number?
     char cmd_buffer[1024];
-    sprintf(cmd_buffer, "dawn.@metric[0].ht_support=%d", blobmsg_get_u32(tb_metric[UCI_HT_SUPPORT]));
+
+    sprintf(cmd_buffer, "%s", "dawn.global=metric");
     uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].vht_support=%d", blobmsg_get_u32(tb_metric[UCI_VHT_SUPPORT]));
+    sprintf(cmd_buffer, "dawn.global.min_probe_count=%d", blobmsg_get_u32(tb_metric[UCI_MIN_PROBE_COUNT]));
     uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].no_ht_support=%d", blobmsg_get_u32(tb_metric[UCI_NO_HT_SUPPORT]));
+    sprintf(cmd_buffer, "dawn.global.bandwidth_threshold=%d", blobmsg_get_u32(tb_metric[UCI_BANDWIDTH_THRESHOLD]));
     uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].no_vht_support=%d", blobmsg_get_u32(tb_metric[UCI_NO_VHT_SUPPORT]));
+    sprintf(cmd_buffer, "dawn.global.use_station_count=%d", blobmsg_get_u32(tb_metric[UCI_USE_STATION_COUNT]));
     uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].rssi=%d", blobmsg_get_u32(tb_metric[UCI_RSSI]));
+    sprintf(cmd_buffer, "dawn.global.max_station_diff=%d", blobmsg_get_u32(tb_metric[UCI_MAX_STATION_DIFF]));
     uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].low_rssi=%d", blobmsg_get_u32(tb_metric[UCI_LOW_RSSI]));
+    sprintf(cmd_buffer, "dawn.global.eval_probe_req=%d", blobmsg_get_u32(tb_metric[UCI_EVAL_PROBE_REQ]));
     uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].freq=%d", blobmsg_get_u32(tb_metric[UCI_FREQ]));
+    sprintf(cmd_buffer, "dawn.global.eval_auth_req=%d", blobmsg_get_u32(tb_metric[UCI_EVAL_AUTH_REQ]));
     uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].chan_util=%d", blobmsg_get_u32(tb_metric[UCI_CHAN_UTIL]));
+    sprintf(cmd_buffer, "dawn.global.eval_assoc_req=%d", blobmsg_get_u32(tb_metric[UCI_EVAL_ASSOC_REQ]));
     uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].rssi_val=%d", blobmsg_get_u32(tb_metric[UCI_RSSI_VAL]));
+    sprintf(cmd_buffer, "dawn.global.kicking=%d", blobmsg_get_u32(tb_metric[UCI_KICKING]));
     uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].low_rssi_val=%d", blobmsg_get_u32(tb_metric[UCI_LOW_RSSI_VAL]));
+    sprintf(cmd_buffer, "dawn.global.deny_auth_reason=%d", blobmsg_get_u32(tb_metric[UCI_DENY_AUTH_REASON]));
     uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].chan_util_val=%d", blobmsg_get_u32(tb_metric[UCI_CHAN_UTIL_VAL]));
+    sprintf(cmd_buffer, "dawn.global.deny_assoc_reason=%d", blobmsg_get_u32(tb_metric[UCI_DENY_ASSOC_REASON]));
     uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].max_chan_util=%d", blobmsg_get_u32(tb_metric[UCI_MAX_CHAN_UTIL]));
+    sprintf(cmd_buffer, "dawn.global.use_driver_recog=%d", blobmsg_get_u32(tb_metric[UCI_USE_DRIVER_RECOG]));
     uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].max_chan_util_val=%d", blobmsg_get_u32(tb_metric[UCI_MAX_CHAN_UTIL_VAL]));
+    sprintf(cmd_buffer, "dawn.global.min_number_to_kick=%d", blobmsg_get_u32(tb_metric[UCI_MIN_NUMBER_TO_KICK]));
     uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].min_probe_count=%d", blobmsg_get_u32(tb_metric[UCI_MIN_PROBE_COUNT]));
+    sprintf(cmd_buffer, "dawn.global.chan_util_avg_period=%d", blobmsg_get_u32(tb_metric[UCI_CHAN_UTIL_AVG_PERIOD]));
     uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].bandwidth_threshold=%d", blobmsg_get_u32(tb_metric[UCI_BANDWIDTH_THRESHOLD]));
+    sprintf(cmd_buffer, "dawn.global.set_hostapd_nr=%d", blobmsg_get_u32(tb_metric[UCI_SET_HOSTAPD_NR]));
     uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].use_station_count=%d", blobmsg_get_u32(tb_metric[UCI_USE_STATION_COUNT]));
+    sprintf(cmd_buffer, "dawn.global.duration=%d", blobmsg_get_u32(tb_metric[UCI_DURATION]));
     uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].max_station_diff=%d", blobmsg_get_u32(tb_metric[UCI_MAX_STATION_DIFF]));
+    sprintf(cmd_buffer, "dawn.global.rrm_mode=%s", blobmsg_get_string(tb_metric[UCI_RRM_MODE]));
     uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].eval_probe_req=%d", blobmsg_get_u32(tb_metric[UCI_EVAL_PROBE_REQ]));
-    uci_set_network(cmd_buffer);
+    struct blob_attr *tb_band_metric[__UCI_BAND_METRIC_MAX], *attr;
+    int band_len = blobmsg_len(tb_metric[UCI_BAND_METRICS]);
+    struct blob_attr *band_data = blobmsg_data(tb_metric[UCI_BAND_METRICS]);
+    __blob_for_each_attr(attr, band_data, band_len) {
+        struct blobmsg_hdr *hdr = blob_data(attr);
+        const char *band_name = (const char *)hdr->name;
+        int band;
 
-    sprintf(cmd_buffer, "dawn.@metric[0].eval_auth_req=%d", blobmsg_get_u32(tb_metric[UCI_EVAL_AUTH_REQ]));
-    uci_set_network(cmd_buffer);
+        blobmsg_parse(uci_band_metric_policy, __UCI_BAND_METRIC_MAX, tb_band_metric,
+                      blobmsg_data(attr), blobmsg_len(attr));
 
-    sprintf(cmd_buffer, "dawn.@metric[0].evalcd_assoc_req=%d", blobmsg_get_u32(tb_metric[UCI_EVAL_ASSOC_REQ]));
-    uci_set_network(cmd_buffer);
+        for (band = 0; band < __DAWN_BAND_MAX; band++) {
+            if (!strcmp(band_name, band_config_name[band]))
+                break;
+        }
+        if (band == __DAWN_BAND_MAX) {
+            fprintf(stderr, "handle_uci_config: Warning: unknown band '%s'.\n", band_name);
+            continue;  // Should we write the metrics of an unknown band to the config file?
+        }
 
-    sprintf(cmd_buffer, "dawn.@metric[0].kicking=%d", blobmsg_get_u32(tb_metric[UCI_KICKING]));
-    uci_set_network(cmd_buffer);
+        sprintf(cmd_buffer, "dawn.%s=metric", band_name);
+        uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].deny_auth_reason=%d", blobmsg_get_u32(tb_metric[UCI_DENY_AUTH_REASON]));
-    uci_set_network(cmd_buffer);
+        sprintf(cmd_buffer, "dawn.%s.freq=%d", band_name, blobmsg_get_u32(tb_band_metric[UCI_FREQ]));
+        uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].deny_assoc_reason=%d", blobmsg_get_u32(tb_metric[UCI_DENY_ASSOC_REASON]));
-    uci_set_network(cmd_buffer);
+        sprintf(cmd_buffer, "dawn.%s.ht_support=%d", band_name, blobmsg_get_u32(tb_band_metric[UCI_HT_SUPPORT]));
+        uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].use_driver_recog=%d", blobmsg_get_u32(tb_metric[UCI_USE_DRIVER_RECOG]));
-    uci_set_network(cmd_buffer);
+        sprintf(cmd_buffer, "dawn.%s.vht_support=%d", band_name, blobmsg_get_u32(tb_band_metric[UCI_VHT_SUPPORT]));
+        uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].min_number_to_kick=%d", blobmsg_get_u32(tb_metric[UCI_MIN_NUMBER_TO_KICK]));
-    uci_set_network(cmd_buffer);
+        sprintf(cmd_buffer, "dawn.%s.no_ht_support=%d", band_name, blobmsg_get_u32(tb_band_metric[UCI_NO_HT_SUPPORT]));
+        uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].chan_util_avg_period=%d", blobmsg_get_u32(tb_metric[UCI_CHAN_UTIL_AVG_PERIOD]));
-    uci_set_network(cmd_buffer);
+        sprintf(cmd_buffer, "dawn.%s.no_vht_support=%d", band_name, blobmsg_get_u32(tb_band_metric[UCI_NO_VHT_SUPPORT]));
+        uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].set_hostapd_nr=%d", blobmsg_get_u32(tb_metric[UCI_SET_HOSTAPD_NR]));
-    uci_set_network(cmd_buffer);
+        sprintf(cmd_buffer, "dawn.%s.rssi=%d", band_name, blobmsg_get_u32(tb_band_metric[UCI_RSSI]));
+        uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].duration=%d", blobmsg_get_u32(tb_metric[UCI_DURATION]));
-    uci_set_network(cmd_buffer);
+        sprintf(cmd_buffer, "dawn.%s.rssi_val=%d", band_name, blobmsg_get_u32(tb_band_metric[UCI_RSSI_VAL]));
+        uci_set_network(cmd_buffer);
 
-    sprintf(cmd_buffer, "dawn.@metric[0].rrm_mode=%s", blobmsg_get_string(tb_metric[UCI_RRM_MODE]));
-    uci_set_network(cmd_buffer);
+        sprintf(cmd_buffer, "dawn.%s.low_rssi_val=%d", band_name, blobmsg_get_u32(tb_band_metric[UCI_LOW_RSSI_VAL]));
+        uci_set_network(cmd_buffer);
+
+        sprintf(cmd_buffer, "dawn.%s.low_rssi=%d", band_name, blobmsg_get_u32(tb_band_metric[UCI_LOW_RSSI]));
+        uci_set_network(cmd_buffer);
+
+        sprintf(cmd_buffer, "dawn.%s.chan_util=%d", band_name, blobmsg_get_u32(tb_band_metric[UCI_CHAN_UTIL]));
+        uci_set_network(cmd_buffer);
+
+        sprintf(cmd_buffer, "dawn.%s.chan_util_val=%d", band_name, blobmsg_get_u32(tb_band_metric[UCI_CHAN_UTIL_VAL]));
+        uci_set_network(cmd_buffer);
+
+        sprintf(cmd_buffer, "dawn.%s.max_chan_util=%d", band_name, blobmsg_get_u32(tb_band_metric[UCI_MAX_CHAN_UTIL]));
+        uci_set_network(cmd_buffer);
+
+        sprintf(cmd_buffer, "dawn.%s.max_chan_util_val=%d", band_name, blobmsg_get_u32(tb_band_metric[UCI_MAX_CHAN_UTIL_VAL]));
+        uci_set_network(cmd_buffer);
+    }
 
     struct blob_attr* tb_times[__UCI_TIMES_MAX];
     blobmsg_parse(uci_times_policy, __UCI_TIMES_MAX, tb_times, blobmsg_data(tb[UCI_TABLE_TIMES]), blobmsg_len(tb[UCI_TABLE_TIMES]));

--- a/src/utils/ubus.c
+++ b/src/utils/ubus.c
@@ -1366,6 +1366,7 @@ int uci_send_via_network()
     void *metric, *times;
 
     blob_buf_init(&b, 0);
+    blobmsg_add_string(&b, "version", DAWN_CONFIG_VERSION);
     metric = blobmsg_open_table(&b, "metric");
     blobmsg_add_u32(&b, "ht_support", dawn_metric.ht_support);
     blobmsg_add_u32(&b, "vht_support", dawn_metric.vht_support);

--- a/src/utils/ubus.c
+++ b/src/utils/ubus.c
@@ -926,7 +926,7 @@ void del_client_interface(uint32_t id, const struct dawn_mac client_addr, uint32
 
 }
 
-int wnm_disassoc_imminent(uint32_t id, const struct dawn_mac client_addr, char *dest_ap, uint32_t duration) {
+int wnm_disassoc_imminent(uint32_t id, const struct dawn_mac client_addr, struct kicking_nr* neighbor_list, uint32_t duration) {
     struct hostapd_sock_entry *sub;
 
     blob_buf_init(&b, 0);
@@ -934,12 +934,11 @@ int wnm_disassoc_imminent(uint32_t id, const struct dawn_mac client_addr, char *
     blobmsg_add_u32(&b, "duration", duration);
     blobmsg_add_u8(&b, "abridged", 1); // prefer aps in neighborlist
 
-    // ToDo: maybe exchange to a list of aps
     void* nbs = blobmsg_open_array(&b, "neighbors");
-    if (dest_ap != NULL)
-    {
-        blobmsg_add_string(&b, NULL, dest_ap);
-        printf("BSS TRANSITION TO %s\n", dest_ap);
+    while(neighbor_list != NULL) {
+        printf("BSS TRANSITION NEIGHBOR " NR_MACSTR ", Score=%d\n", NR_MAC2STR(neighbor_list->nr), neighbor_list->score);
+        blobmsg_add_string(&b, NULL, neighbor_list->nr);
+        neighbor_list = neighbor_list->next;
     }
 
     blobmsg_close_array(&b, nbs);

--- a/src/utils/ubus.c
+++ b/src/utils/ubus.c
@@ -1448,6 +1448,7 @@ int uci_send_via_network()
     blobmsg_add_u32(&b, "eval_auth_req", dawn_metric.eval_auth_req);
     blobmsg_add_u32(&b, "eval_assoc_req", dawn_metric.eval_assoc_req);
     blobmsg_add_u32(&b, "kicking", dawn_metric.kicking);
+    blobmsg_add_u32(&b, "kicking_threshold", dawn_metric.kicking_threshold);
     blobmsg_add_u32(&b, "deny_auth_reason", dawn_metric.deny_auth_reason);
     blobmsg_add_u32(&b, "deny_assoc_reason", dawn_metric.deny_assoc_reason);
     blobmsg_add_u32(&b, "use_driver_recog", dawn_metric.use_driver_recog);
@@ -1460,6 +1461,7 @@ int uci_send_via_network()
 
     for (int band=0; band < __DAWN_BAND_MAX; band++) {
         band_entry = blobmsg_open_table(&b, band_config_name[band]);
+        blobmsg_add_u32(&b, "initial_score", dawn_metric.initial_score[band]);
         blobmsg_add_u32(&b, "ap_weight", dawn_metric.ap_weight[band]);
         blobmsg_add_u32(&b, "ht_support", dawn_metric.ht_support[band]);
         blobmsg_add_u32(&b, "vht_support", dawn_metric.vht_support[band]);
@@ -1469,11 +1471,12 @@ int uci_send_via_network()
         blobmsg_add_u32(&b, "rssi_val", dawn_metric.rssi_val[band]);
         blobmsg_add_u32(&b, "low_rssi", dawn_metric.low_rssi[band]);
         blobmsg_add_u32(&b, "low_rssi_val", dawn_metric.low_rssi_val[band]);
-        blobmsg_add_u32(&b, "freq", dawn_metric.freq[band]);
         blobmsg_add_u32(&b, "chan_util", dawn_metric.chan_util[band]);
         blobmsg_add_u32(&b, "max_chan_util", dawn_metric.max_chan_util[band]);
         blobmsg_add_u32(&b, "chan_util_val", dawn_metric.chan_util_val[band]);
         blobmsg_add_u32(&b, "max_chan_util_val", dawn_metric.max_chan_util_val[band]);
+        blobmsg_add_u32(&b, "rssi_weight", dawn_metric.rssi_weight[band]);
+        blobmsg_add_u32(&b, "rssi_center", dawn_metric.rssi_center[band]);
         blobmsg_close_table(&b, band_entry);
     }
     blobmsg_close_table(&b, band_table);


### PR DESCRIPTION
These are things I'm working on right now.  The first couple of commits should be ready to push, if desired.  The `DAWN_NO_OUTPUT` change needs to be completed and rebased before pushing, but should be easy enough.

The other commits should be working OK, but there are a few points I would like to discuss.

1. I intend to group global/11a/11g config options to different sections, such as:
* global_metric
* 80211a_metric
* 80211b_metric

2. The commits are not here yet, but I'm trying to come up with a way to include the signal value directly into the score, adding a threshold to avoid bouncing back and forth.   I'm using ([Signal] - [Center])*[Weight] to have a numerical score.  I'm using different weights for a and g bands, so that A band will be preferred with higher signal, and G is when poor.  Kicking only occurs if the score difference is above a configurable threshold.  Here's a display of my current attempt, comparing APs in different bands:

![image](https://user-images.githubusercontent.com/35331380/127338886-4b1f394e-72ad-4fc4-93a4-aca5bc2ccdfc.png)

I've marked the area around 70dBm, as that's where Apple devices start their search for a new AP.  The diagonal where signal strengths are close are also marked.
One _caveat_ of this strategy is that, since I'm multiplying the signal score by 2 (in that example), when comparing two APs in the same band, the neutral zone in the A-band is half as wide as the G-band.  Here are the intra-band graphs:

![image](https://user-images.githubusercontent.com/35331380/127340440-427a2251-dae4-4888-a189-f64c0bbc790e.png)
![image](https://user-images.githubusercontent.com/35331380/127340459-d22d45ba-4901-471d-be41-f9927c7949a6.png)
 