### PR TITLE
Multiple Changes

### DIFF
--- a/src/crypto/crypto.c
+++ b/src/crypto/crypto.c
@@ -98,16 +98,19 @@ char *gcrypt_decrypt_msg(char *msg, size_t msg_length) {
                 gcry_strsource(gcry_error_handle),
                 gcry_strerror(gcry_error_handle));
         dawn_free(out_buffer);
+        out_buffer = NULL;
         return NULL;
     }
     char *out = dawn_malloc(strlen(out_buffer) + 1);
     if (!out){
         dawn_free(out_buffer);
+        out_buffer = NULL;
         dawnlog_error("gcry_cipher_decrypt error: not enough memory\n");
         return NULL;
     }
     strcpy(out, out_buffer);
     dawn_free(out_buffer);
+    out_buffer = NULL;
     return out;
 }
 

--- a/src/crypto/crypto.c
+++ b/src/crypto/crypto.c
@@ -3,6 +3,7 @@
 
 #include <gcrypt.h>
 
+#include "utils.h"
 #include "memory_utils.h"
 #include "crypto.h"
 
@@ -14,7 +15,7 @@ gcry_cipher_hd_t gcry_cipher_hd;
 
 void gcrypt_init() {
     if (!gcry_check_version(GCRYPT_VERSION)) {
-        fprintf(stderr, "gcrypt: library version mismatch");
+        dawnlog_error("gcrypt: library version mismatch");
     }
     gcry_error_t err = 0;
     err = gcry_control(GCRYCTL_SUSPEND_SECMEM_WARN);
@@ -23,7 +24,7 @@ void gcrypt_init() {
     err |= gcry_control(GCRYCTL_INITIALIZATION_FINISHED, 0);
 
     if (err) {
-        fprintf(stderr, "gcrypt: failed initialization");
+        dawnlog_error("gcrypt: failed initialization");
     }
 }
 
@@ -37,7 +38,7 @@ void gcrypt_set_key_and_iv(const char *key, const char *iv) {
             GCRY_C_MODE,   // int
             0);
     if (gcry_error_handle) {
-        fprintf(stderr, "gcry_cipher_open failed:  %s/%s\n",
+        dawnlog_error("gcry_cipher_open failed:  %s/%s\n",
                 gcry_strsource(gcry_error_handle),
                 gcry_strerror(gcry_error_handle));
         return;
@@ -45,7 +46,7 @@ void gcrypt_set_key_and_iv(const char *key, const char *iv) {
 
     gcry_error_handle = gcry_cipher_setkey(gcry_cipher_hd, key, keylen);
     if (gcry_error_handle) {
-        fprintf(stderr, "gcry_cipher_setkey failed:  %s/%s\n",
+        dawnlog_error("gcry_cipher_setkey failed:  %s/%s\n",
                 gcry_strsource(gcry_error_handle),
                 gcry_strerror(gcry_error_handle));
         return;
@@ -53,7 +54,7 @@ void gcrypt_set_key_and_iv(const char *key, const char *iv) {
 
     gcry_error_handle = gcry_cipher_setiv(gcry_cipher_hd, iv, blklen);
     if (gcry_error_handle) {
-        fprintf(stderr, "gcry_cipher_setiv failed:  %s/%s\n",
+        dawnlog_error("gcry_cipher_setiv failed:  %s/%s\n",
                 gcry_strsource(gcry_error_handle),
                 gcry_strerror(gcry_error_handle));
         return;
@@ -67,12 +68,12 @@ char *gcrypt_encrypt_msg(char *msg, size_t msg_length, int *out_length) {
 
     char *out = dawn_malloc(msg_length);
     if (!out){
-        fprintf(stderr, "gcry_cipher_encrypt error: not enought memory\n");
+        dawnlog_error("gcry_cipher_encrypt error: not enough memory\n");
         return NULL;
     }
     gcry_error_handle = gcry_cipher_encrypt(gcry_cipher_hd, out, msg_length, msg, msg_length);
     if (gcry_error_handle) {
-        fprintf(stderr, "gcry_cipher_encrypt failed:  %s/%s\n",
+        dawnlog_error("gcry_cipher_encrypt failed:  %s/%s\n",
                 gcry_strsource(gcry_error_handle),
                 gcry_strerror(gcry_error_handle));
         return NULL;
@@ -88,12 +89,12 @@ char *gcrypt_decrypt_msg(char *msg, size_t msg_length) {
 
     char *out_buffer = dawn_malloc(msg_length);
     if (!out_buffer){
-        fprintf(stderr, "gcry_cipher_decrypt error: not enought memory\n");
+        dawnlog_error("gcry_cipher_decrypt error: not enough memory\n");
         return NULL;
     }
     gcry_error_handle = gcry_cipher_decrypt(gcry_cipher_hd, out_buffer, msg_length, msg, msg_length);
     if (gcry_error_handle) {
-        fprintf(stderr, "gcry_cipher_decrypt failed:  %s/%s\n",
+        dawnlog_error("gcry_cipher_decrypt failed:  %s/%s\n",
                 gcry_strsource(gcry_error_handle),
                 gcry_strerror(gcry_error_handle));
         dawn_free(out_buffer);
@@ -102,7 +103,7 @@ char *gcrypt_decrypt_msg(char *msg, size_t msg_length) {
     char *out = dawn_malloc(strlen(out_buffer) + 1);
     if (!out){
         dawn_free(out_buffer);
-        fprintf(stderr, "gcry_cipher_decrypt error: not enought memory\n");
+        dawnlog_error("gcry_cipher_decrypt error: not enough memory\n");
         return NULL;
     }
     strcpy(out, out_buffer);

--- a/src/include/datastorage.h
+++ b/src/include/datastorage.h
@@ -127,6 +127,10 @@ struct time_config_s {
     time_t update_beacon_reports;
 };
 
+struct local_config_s {
+    int loglevel;
+};
+
 #define MAX_IP_LENGTH 46
 #define MAX_KEY_LENGTH 65
 
@@ -145,12 +149,10 @@ struct network_config_s {
 
 extern struct network_config_s network_config;
 extern struct time_config_s timeout_config;
+extern struct local_config_s local_config;
 extern struct probe_metric_s dawn_metric;
 
 /*** Core DAWN data structures for tracking network devices and status ***/
-// Define this to remove printing / reporing of fields, and hence observe
-// which fields are evaluated in use at compile time.
-// #define DAWN_NO_OUTPUT
 
 // TODO notes:
 //    Never used? = No code reference
@@ -174,11 +176,9 @@ typedef struct probe_entry_s {
     uint8_t vht_capabilities; // eval_probe_metric()
     time_t time; // remove_old...entries
     int counter;
-#ifndef DAWN_NO_OUTPUT
     int deny_counter; // TODO: Never used?
     uint8_t max_supp_datarate; // TODO: Never used?
     uint8_t min_supp_datarate; // TODO: Never used?
-#endif
     uint32_t rcpi;
     uint32_t rsni;
 } probe_entry;
@@ -316,7 +316,7 @@ void remove_old_probe_entries(time_t current_time, long long int threshold);
 
 void print_probe_array();
 
-void print_probe_entry(probe_entry *entry);
+void print_probe_entry(int level, probe_entry *entry);
 
 int eval_probe_metric(struct probe_entry_s * probe_entry, ap *ap_entry);
 
@@ -326,7 +326,7 @@ auth_entry *insert_to_denied_req_array(auth_entry*entry, int inc_counter, time_t
 
 void remove_old_denied_req_entries(time_t current_time, long long int threshold, int logmac);
 
-void print_auth_entry(auth_entry *entry);
+void print_auth_entry(int level, auth_entry *entry);
 
 // ---------------- Functions ----------------
 
@@ -350,7 +350,7 @@ client *client_array_delete(client *entry, int unlink_only);
 
 void print_client_array();
 
-void print_client_entry(client *entry);
+void print_client_entry(int level, client *entry);
 
 int is_connected_somehwere(struct dawn_mac client_addr);
 

--- a/src/include/datastorage.h
+++ b/src/include/datastorage.h
@@ -9,16 +9,9 @@
 #include "mac_utils.h"
 #include "utils.h"
 
-// Core data storage array sizes
-#define ARRAY_AP_LEN 100
-#define ARRAY_CLIENT_LEN 300
-#define PROBE_ARRAY_LEN 1000
-#define DENY_REQ_ARRAY_LEN 100
-
 /* Mac */
 
 // ---------------- Defines -------------------
-#define MAC_LIST_LENGTH 100
 #define DEFAULT_RRM_MODE_ORDER "pat"
 #define RRM_MODE_COUNT 3
 

--- a/src/include/dawn_uci.h
+++ b/src/include/dawn_uci.h
@@ -29,6 +29,12 @@ struct probe_metric_s uci_get_dawn_metric();
 struct time_config_s uci_get_time_config();
 
 /**
+ * Function that returns a struct with all the local config values.
+ * @return the local config values.
+ */
+struct local_config_s uci_get_local_config();
+
+/**
  * Function that returns all the network informations.
  * @return the network config values.
  */

--- a/src/include/msghandler.h
+++ b/src/include/msghandler.h
@@ -41,7 +41,6 @@ int parse_to_hostapd_notify(struct blob_attr* msg, hostapd_notify_entry* notify_
  */
 int handle_network_msg(char* msg);
 
-
 int handle_deauth_req(struct blob_attr* msg);
 
 #endif

--- a/src/include/tcpsocket.h
+++ b/src/include/tcpsocket.h
@@ -21,7 +21,7 @@ struct network_con_s {
  * @param port
  * @return
  */
-int add_tcp_conncection(char *ipv4, int port);
+int add_tcp_connection(char *ipv4, int port);
 
 /**
  * Opens a tcp server and adds it to the uloop.

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -2,6 +2,7 @@
 #define __DAWN_UTILS_H
 
 #include <stdint.h>
+#include <syslog.h>
 
 /**
  * Check if a string is greater than another one.
@@ -11,4 +12,91 @@
  */
 int string_is_greater(char *str, char *str_2);
 
+
+/*
+**  Log handling for dawn process
+*/
+#define DAWNLOG_DEST_SYSLOG 0 // Send log output to syslog...
+#define DAWNLOG_DEST_STDIO  1 // ... or stdout / stderr as appropriate
+
+#define DAWNLOG_PERROR  0x08  // Bit flag to signal inclusion of errno from system calls
+
+#define DAWNLOG_PRIMASK 0x07  // Bitmask to obtain only priority value
+
+#define DAWNLOG_ERROR   5  // Serious malfunction / unexpected behaviour - eg: OS resource exhaustion
+#define DAWNLOG_WARNING 4  // Something appears wrong, but recoverable - eg: data structures inconsistent
+#define DAWNLOG_ALWAYS  3  // Standard behaviour always worth reporting - should be very low frequency messages
+#define DAWNLOG_INFO    2  // Reporting on standard behaviour - should be comprehensible to user
+#define DAWNLOG_TRACE   1  // More info to help trace where algorithms may be going wrong
+#define DAWNLOG_DEBUG   0  // Deeper tracing to fix bugs
+
+#define DAWNLOG_COMPILE_MIN DAWNLOG_DEBUG // Messages lower than this priority are not compiled
+#define DAWNLOG_COMPILING(level) (level >= DAWNLOG_COMPILE_MIN)
+
+#define dawnlog_perror(s, ...) dawnlog(DAWNLOG_ERROR|DAWNLOG_PERROR, "%s()=%s@%d %s - " s, __func__, dawnlog_basename(__FILE__), __LINE__, dawnlog_pbuf, ##__VA_ARGS__)
+#define dawnlog_error(fmt, ...) dawnlog(DAWNLOG_ERROR, "%s()=%s@%d " fmt, __func__, dawnlog_basename(__FILE__), __LINE__, ##__VA_ARGS__)
+
+#define dawnlog_warning(fmt, ...) dawnlog(DAWNLOG_WARNING, fmt, ##__VA_ARGS__)
+
+#define dawnlog_always(fmt, ...) dawnlog(DAWNLOG_ALWAYS, fmt, ##__VA_ARGS__)
+
+#if DAWNLOG_COMPILING(DAWNLOG_INFO)
+#define dawnlog_info(fmt, ...) dawnlog(DAWNLOG_INFO, fmt, ##__VA_ARGS__)
+#else
+#define dawnlog_info(fmt, ...)
+#endif
+
+// Use the ..._func variants to get source code position added automatically: function, filename, line
+#if DAWNLOG_COMPILING(DAWNLOG_TRACE)
+#define dawnlog_trace(fmt, ...) dawnlog(DAWNLOG_TRACE, fmt, ##__VA_ARGS__)
+#define dawnlog_trace_func(fmt, ...) dawnlog(DAWNLOG_TRACE, "%s()=%s@%d "  fmt, __func__, dawnlog_basename(__FILE__), __LINE__, ##__VA_ARGS__)
+#else
+#define dawnlog_trace(fmt, ...)
+#define dawnlog_trace_func(fmt, ...)
+#endif
+
+#if DAWNLOG_COMPILING(DAWNLOG_DEBUG)
+#define dawnlog_debug(fmt, ...) dawnlog(DAWNLOG_DEBUG, fmt, ##__VA_ARGS__)
+#define dawnlog_debug_func(fmt, ...) dawnlog(DAWNLOG_DEBUG, "%s()=%s@%d "  fmt, __func__, dawnlog_basename(__FILE__), __LINE__, ##__VA_ARGS__)
+#else
+#define dawnlog_debug(fmt, ...)
+#define dawnlog_debug_func(fmt, ...)
+#endif
+
+extern char dawnlog_pbuf[];  // Buffer for errno conversion for dawnlog_perror()
+
+/**
+ * Set the output target for dawnlog()
+ * @param logdest: DAWNLOG_DEST_*
+ */
+void dawnlog_dest(int logdest);
+
+/**
+ * Minimum priority level to be logged
+ * @param level: A priority level
+ */
+void dawnlog_minlevel(int level);
+
+/**
+ * Check whether a priority level would be actually logged to allow callers
+ * to skip "expensive" preparation such as string manipulation or loops
+ * @param level
+ * @return TRUE if the priority level would be logged
+ */
+int dawnlog_showing(int level);
+
+/**
+ * Log a message.
+ * @param level
+ * @param fmt
+ * @return
+ */
+void dawnlog(int level, const char* fmt, ...);
+
+/**
+ * Return pointer to filename part of full path.
+ * @param file
+ * @return
+ */
+const char* dawnlog_basename(const char* file);
 #endif

--- a/src/network/broadcastsocket.c
+++ b/src/network/broadcastsocket.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "utils.h"
 #include "broadcastsocket.h"
 
 int setup_broadcast_socket(const char *_broadcast_ip, unsigned short _broadcast_port, struct sockaddr_in *addr) {
@@ -10,7 +11,7 @@ int setup_broadcast_socket(const char *_broadcast_ip, unsigned short _broadcast_
 
     // Create socket
     if ((sock = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
-        fprintf(stderr, "Failed to create socket.\n");
+        dawnlog_error("Failed to create socket.\n");
         return -1;
     }
 
@@ -18,7 +19,7 @@ int setup_broadcast_socket(const char *_broadcast_ip, unsigned short _broadcast_
     broadcast_permission = 1;
     if (setsockopt(sock, SOL_SOCKET, SO_BROADCAST, (void *) &broadcast_permission,
                    sizeof(broadcast_permission)) < 0) {
-        fprintf(stderr, "Failed to create socket.\n");
+        dawnlog_error("Failed to create socket.\n");
         return -1;
     }
 
@@ -30,7 +31,7 @@ int setup_broadcast_socket(const char *_broadcast_ip, unsigned short _broadcast_
 
     // Bind socket
     while (bind(sock, (struct sockaddr *) addr, sizeof(*addr)) < 0) {
-        fprintf(stderr, "Binding socket failed!\n");
+        dawnlog_error("Binding socket failed!\n");
         sleep(1);
     }
     return sock;

--- a/src/network/multicastsocket.c
+++ b/src/network/multicastsocket.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "utils.h"
 #include "multicastsocket.h"
 
 // based on: http://openbook.rheinwerk-verlag.de/linux_unix_programmierung/Kap11-018.htm
@@ -18,7 +19,7 @@ int setup_multicast_socket(const char *_multicast_ip, unsigned short _multicast_
     addr->sin_port = htons (_multicast_port);
 
     if ((sock = socket(PF_INET, SOCK_DGRAM, 0)) == -1) {
-        perror("socket()");
+        dawnlog_perror("socket()");
         exit(EXIT_FAILURE);
     }
 
@@ -28,13 +29,13 @@ int setup_multicast_socket(const char *_multicast_ip, unsigned short _multicast_
                    SOL_SOCKET,
                    SO_REUSEADDR,
                    &loop, sizeof(loop)) < 0) {
-        perror("setsockopt:SO_REUSEADDR");
+        dawnlog_perror("setsockopt:SO_REUSEADDR");
         exit(EXIT_FAILURE);
     }
     if (bind(sock,
              (struct sockaddr *) addr,
              sizeof(*addr)) < 0) {
-        perror("bind");
+        dawnlog_perror("bind");
         exit(EXIT_FAILURE);
     }
 
@@ -44,7 +45,7 @@ int setup_multicast_socket(const char *_multicast_ip, unsigned short _multicast_
                    IPPROTO_IP,
                    IP_MULTICAST_LOOP,
                    &loop, sizeof(loop)) < 0) {
-        perror("setsockopt:IP_MULTICAST_LOOP");
+        dawnlog_perror("setsockopt:IP_MULTICAST_LOOP");
         exit(EXIT_FAILURE);
     }
 
@@ -52,14 +53,14 @@ int setup_multicast_socket(const char *_multicast_ip, unsigned short _multicast_
     command.imr_multiaddr.s_addr = inet_addr(_multicast_ip);
     command.imr_interface.s_addr = htonl (INADDR_ANY);
     if (command.imr_multiaddr.s_addr == -1) {
-        perror("Wrong multicast address!\n");
+        dawnlog_perror("Wrong multicast address!\n");
         exit(EXIT_FAILURE);
     }
     if (setsockopt(sock,
                    IPPROTO_IP,
                    IP_ADD_MEMBERSHIP,
                    &command, sizeof(command)) < 0) {
-        perror("setsockopt:IP_ADD_MEMBERSHIP");
+        dawnlog_perror("setsockopt:IP_ADD_MEMBERSHIP");
     }
     return sock;
 }
@@ -69,7 +70,7 @@ int remove_multicast_socket(int socket) {
                    IPPROTO_IP,
                    IP_DROP_MEMBERSHIP,
                    &command, sizeof(command)) < 0) {
-        perror("setsockopt:IP_DROP_MEMBERSHIP");
+        dawnlog_perror("setsockopt:IP_DROP_MEMBERSHIP");
         return -1;
     }
     return 0;

--- a/src/network/networksocket.c
+++ b/src/network/networksocket.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include <libubox/blobmsg_json.h>
 
+#include "utils.h"
 #include "memory_utils.h"
 #include "multicastsocket.h"
 #include "broadcastsocket.h"
@@ -37,9 +38,7 @@ int init_socket_runopts(const char *_ip, int _port, int _multicast_socket) {
     multicast_socket = _multicast_socket;
 
     if (multicast_socket) {
-#ifndef DAWN_NO_OUTPUT
-        printf("Settingup multicastsocket!\n");
-#endif
+        dawnlog_info("Settingup multicastsocket!\n");
         sock = setup_multicast_socket(ip, port, &addr);
     } else {
         sock = setup_broadcast_socket(ip, port, &addr);
@@ -48,19 +47,17 @@ int init_socket_runopts(const char *_ip, int _port, int _multicast_socket) {
     pthread_t sniffer_thread;
     if (network_config.use_symm_enc) {
         if (pthread_create(&sniffer_thread, NULL, receive_msg_enc, NULL)) {
-            fprintf(stderr, "Could not create receiving thread!\n");
+            dawnlog_error("Could not create receiving thread!\n");
             return -1;
         }
     } else {
         if (pthread_create(&sniffer_thread, NULL, receive_msg, NULL)) {
-            fprintf(stderr, "Could not create receiving thread!\n");
+            dawnlog_error("Could not create receiving thread!\n");
             return -1;
         }
     }
 
-#ifndef DAWN_NO_OUTPUT
-    fprintf(stdout, "Connected to %s:%d\n", ip, port);
-#endif
+    dawnlog_info("Connected to %s:%d\n", ip, port);
 
     return 0;
 }
@@ -69,7 +66,7 @@ void *receive_msg(void *args) {
     while (1) {
         if ((recv_string_len =
                      recvfrom(sock, recv_string, MAX_RECV_STRING, 0, NULL, 0)) < 0) {
-            fprintf(stderr, "Could not receive message!");
+            dawnlog_error("Could not receive message!");
             continue;
         }
 
@@ -83,9 +80,7 @@ void *receive_msg(void *args) {
         }
         recv_string[recv_string_len] = '\0';
 
-#ifndef DAWN_NO_OUTPUT
-        printf("Received network message: %s\n", recv_string);
-#endif
+        dawnlog_debug("Received network message: %s\n", recv_string);
         handle_network_msg(recv_string);
     }
 }
@@ -94,7 +89,7 @@ void *receive_msg_enc(void *args) {
     while (1) {
         if ((recv_string_len =
                      recvfrom(sock, recv_string, MAX_RECV_STRING, 0, NULL, 0)) < 0) {
-            fprintf(stderr, "Could not receive message!\n");
+            dawnlog_error("Could not receive message!\n");
             continue;
         }
 
@@ -110,20 +105,18 @@ void *receive_msg_enc(void *args) {
 
         char *base64_dec_str = dawn_malloc(B64_DECODE_LEN(strlen(recv_string)));
         if (!base64_dec_str){
-            fprintf(stderr, "Received network error: not enough memory\n");
+            dawnlog_error("Received network error: not enough memory\n");
             return 0;
         }
         int base64_dec_length = b64_decode(recv_string, base64_dec_str, B64_DECODE_LEN(strlen(recv_string)));
         char *dec = gcrypt_decrypt_msg(base64_dec_str, base64_dec_length);
         if (!dec){
             dawn_free(base64_dec_str);
-            fprintf(stderr, "Received network error: not enough memory\n");
+            dawnlog_error("Received network error: not enough memory\n");
             return 0;
         }
 
-#ifndef DAWN_NO_OUTPUT
-        printf("Received network message: %s\n", dec);
-#endif
+        dawnlog_debug("Received network message: %s\n", dec);
         dawn_free(base64_dec_str);
         handle_network_msg(dec);
         dawn_free(dec);
@@ -140,7 +133,7 @@ int send_string(char *msg) {
                0,
                (struct sockaddr *) &addr,
                sizeof(addr)) < 0) {
-        perror("sendto()");
+        dawnlog_perror("sendto()");
         pthread_mutex_unlock(&send_mutex);
         exit(EXIT_FAILURE);
     }
@@ -156,7 +149,7 @@ int send_string_enc(char *msg) {
     size_t msglen = strlen(msg);
     char *enc = gcrypt_encrypt_msg(msg, msglen + 1, &length_enc);
     if (!enc){
-        fprintf(stderr, "sendto() error: not enough memory\n");
+        dawnlog_error("sendto() error: not enough memory\n");
         pthread_mutex_unlock(&send_mutex);
         exit(EXIT_FAILURE);
     }
@@ -164,7 +157,7 @@ int send_string_enc(char *msg) {
     char *base64_enc_str = dawn_malloc(B64_ENCODE_LEN(length_enc));
     if (!base64_enc_str){
         dawn_free(enc);
-        fprintf(stderr, "sendto() error: not enough memory\n");
+        dawnlog_error("sendto() error: not enough memory\n");
         pthread_mutex_unlock(&send_mutex);
         exit(EXIT_FAILURE);
     }
@@ -176,7 +169,7 @@ int send_string_enc(char *msg) {
                0,
                (struct sockaddr *) &addr,
                sizeof(addr)) < 0) {
-        perror("sendto()");
+        dawnlog_perror("sendto()");
         pthread_mutex_unlock(&send_mutex);
         exit(EXIT_FAILURE);
     }

--- a/src/network/networksocket.c
+++ b/src/network/networksocket.c
@@ -112,14 +112,17 @@ void *receive_msg_enc(void *args) {
         char *dec = gcrypt_decrypt_msg(base64_dec_str, base64_dec_length);
         if (!dec){
             dawn_free(base64_dec_str);
+            base64_dec_str = NULL;
             dawnlog_error("Received network error: not enough memory\n");
             return 0;
         }
 
         dawnlog_debug("Received network message: %s\n", dec);
         dawn_free(base64_dec_str);
+        base64_dec_str = NULL;
         handle_network_msg(dec);
         dawn_free(dec);
+        dec = NULL;
     }
 }
 
@@ -157,6 +160,7 @@ int send_string_enc(char *msg) {
     char *base64_enc_str = dawn_malloc(B64_ENCODE_LEN(length_enc));
     if (!base64_enc_str){
         dawn_free(enc);
+        enc = NULL;
         dawnlog_error("sendto() error: not enough memory\n");
         pthread_mutex_unlock(&send_mutex);
         exit(EXIT_FAILURE);
@@ -174,7 +178,9 @@ int send_string_enc(char *msg) {
         exit(EXIT_FAILURE);
     }
     dawn_free(base64_enc_str);
+    base64_enc_str = NULL;
     dawn_free(enc);
+    enc = NULL;
     pthread_mutex_unlock(&send_mutex);
     return 0;
 }

--- a/src/network/tcpsocket.c
+++ b/src/network/tcpsocket.c
@@ -56,10 +56,12 @@ static void client_notify_write(struct ustream *s, int bytes) {
     return;
 }
 
-static void client_notify_state(struct ustream *s) {
-    struct client *cl = container_of(s,
-    struct client, s.stream);
 
+// FIXME: This void function tries to return a value sometimes...
+static void client_notify_state(struct ustream *s) {
+    dawnlog_debug_func("Entering...");
+
+    struct client *cl = container_of(s, struct client, s.stream);
     if (!s->eof)
         return;
 
@@ -71,8 +73,7 @@ static void client_notify_state(struct ustream *s) {
 }
 
 static void client_to_server_close(struct ustream *s) {
-    struct network_con_s *con = container_of(s,
-    struct network_con_s, stream.stream);
+    struct network_con_s *con = container_of(s, struct network_con_s, stream.stream);
 
     dawnlog_debug_func("Entering...");
 
@@ -87,8 +88,7 @@ static void client_to_server_close(struct ustream *s) {
 }
 
 static void client_to_server_state(struct ustream *s) {
-    struct client *cl = container_of(s,
-    struct client, s.stream);
+    struct client *cl = container_of(s, struct client, s.stream);
 
     dawnlog_debug_func("Entering...");
 
@@ -289,7 +289,7 @@ static void connect_cb(struct uloop_fd *f, unsigned int events) {
     entry->connected = 1;
 }
 
-int add_tcp_conncection(char *ipv4, int port) {
+int add_tcp_connection(char *ipv4, int port) {
     struct sockaddr_in serv_addr;
 
     dawnlog_debug_func("Entering...");

--- a/src/storage/datastorage.c
+++ b/src/storage/datastorage.c
@@ -1233,15 +1233,12 @@ ap *insert_to_ap_array(ap* entry, time_t expiry) {
 
     pthread_mutex_lock(&ap_array_mutex);
 
-    // TODO: Why do we delete and add here?
+    // TODO: Why do we delete and add here rather than update existing?
     ap* old_entry = *ap_array_find_first_entry(entry->bssid_addr, entry->ssid);
 
     if (old_entry != NULL &&
-            !mac_is_equal_bb((old_entry)->bssid_addr, entry->bssid_addr) &&
+            mac_is_equal_bb((old_entry)->bssid_addr, entry->bssid_addr) &&
             !strcmp((char*)old_entry->ssid, (char*)entry->ssid))
-        old_entry = NULL;
-
-    if (old_entry != NULL)
         ap_array_delete(old_entry);
 
     entry->time = expiry;

--- a/src/storage/datastorage.c
+++ b/src/storage/datastorage.c
@@ -721,7 +721,7 @@ int kick_clients(ap* kicking_ap, uint32_t id) {
                dawnlog_debug("Check if client is active receiving!\n");
 
                 float rx_rate, tx_rate;
-                bool have_bandwidth_iwinfo = !(get_bandwidth_iwinfo(j->client_addr, &rx_rate, &tx_rate));
+                bool have_bandwidth_iwinfo = get_bandwidth_iwinfo(j->client_addr, &rx_rate, &tx_rate);
                 if (!have_bandwidth_iwinfo && dawn_metric.bandwidth_threshold > 0) {
                    dawnlog_debug("No active transmission data for client. Don't kick!\n");
                 }

--- a/src/storage/datastorage.c
+++ b/src/storage/datastorage.c
@@ -90,7 +90,7 @@ static const struct dawn_mac dawn_mac_null = { .u8 = {0,0,0,0,0,0} };
 ** then the target element does not exist, but can be inserted by using the returned reference.
 */
 
-static struct probe_entry_s** probe_skip_array_find_first_entry(struct dawn_mac client_mac, struct dawn_mac bssid_mac, int do_bssid)
+static struct probe_entry_s** probe_skip_array_find_first_entry(struct dawn_mac client_mac, struct dawn_mac bssid_mac, bool do_bssid)
 {
     int lo = 0;
     struct probe_entry_s** lo_ptr = &probe_skip_set;
@@ -906,10 +906,6 @@ void client_array_insert(client *entry, client** insert_pos) {
 
     client_entry_last++;
 
-    if (client_entry_last == ARRAY_CLIENT_LEN) {
-        dawnlog_warning("client_array overflowing (now contains %d entries)!\n", client_entry_last);
-    }
-
     // Try to keep skip list density stable
     if ((client_entry_last / DAWN_CLIENT_SKIP_RATIO) > client_skip_entry_last)
     {
@@ -1220,10 +1216,6 @@ probe_entry* insert_to_array(probe_entry* entry, int inc_counter, int save_80211
         *existing_entry = entry;
         probe_entry_last++;
 
-        if (probe_entry_last == PROBE_ARRAY_LEN) {
-           dawnlog_warning("probe_array overflowing (now contains %d entries)!\n", probe_entry_last);
-        }
-
         // Try to keep skip list density stable
         if ((probe_entry_last / DAWN_PROBE_SKIP_RATIO) > probe_skip_entry_last)
         {
@@ -1299,10 +1291,6 @@ void ap_array_insert(ap* entry) {
     entry->next_ap = *i;
     *i = entry;
     ap_entry_last++;
-
-    if (ap_entry_last == ARRAY_AP_LEN) {
-        dawnlog_warning("ap_array overflowing (contains %d entries)!\n", ap_entry_last);
-    }
 }
 
 ap* ap_array_get_ap(struct dawn_mac bssid_mac, const uint8_t* ssid) {
@@ -1451,7 +1439,7 @@ void insert_macs_from_file() {
     ssize_t read;
 
     dawnlog_debug_func("Entering...");
-// TODO: Loading to array is not constrained by array checks.  Buffer overrun can occur.
+
     fp = fopen("/tmp/dawn_mac_list", "r");
     if (fp == NULL)
     {
@@ -1596,10 +1584,6 @@ auth_entry* insert_to_denied_req_array(auth_entry* entry, int inc_counter, time_
         entry->next_auth = *i;
         *i = entry;
         denied_req_last++;
-
-        if (denied_req_last == DENY_REQ_ARRAY_LEN) {
-           dawnlog_warning("denied_req_array overflowing (now contains %d entries)!\n", denied_req_last);
-        }
     }
 
     pthread_mutex_unlock(&denied_array_mutex);
@@ -1635,10 +1619,6 @@ struct mac_entry_s* insert_to_mac_array(struct mac_entry_s* entry, struct mac_en
     entry->next_mac = *insert_pos;
     *insert_pos = entry;
     mac_set_last++;
-
-    if (mac_set_last == DENY_REQ_ARRAY_LEN) {
-        dawnlog_warning("denied_req_array overflowing (now contains %d entries)!\n", mac_set_last);
-    }
 
     return entry;
 }

--- a/src/test/test_storage.c
+++ b/src/test/test_storage.c
@@ -493,7 +493,8 @@ static int consume_actions(int argc, char* argv[], int harness_verbosity)
         {
             args_required = 1;
 
-            print_probe_array();
+            if (dawnlog_showing(DAWNLOG_INFO))
+                print_probe_array();
         }
         else if (strcmp(*argv, "client_show") == 0)
         {
@@ -505,11 +506,11 @@ static int consume_actions(int argc, char* argv[], int harness_verbosity)
         {
             args_required = 1;
 
-            printf("--------APs------\n");
+            dawnlog_info("--------APs------\n");
             for (auth_entry *i = denied_req_set; i != NULL; i = i->next_auth) {
-                print_auth_entry(i);
+                print_auth_entry(DAWNLOG_INFO, i);
             }
-            printf("------------------\n");
+            dawnlog_info("------------------\n");
         }
         else if (strcmp(*argv, "ap_add_auto") == 0)
         {
@@ -893,11 +894,9 @@ static int consume_actions(int argc, char* argv[], int harness_verbosity)
                 else if (!strncmp(fn, "vht_cap=", 8)) load_u8(&pr0->vht_capabilities, fn + 8);
                 else if (!strncmp(fn, "time=", 5)) load_time(&pr0->time, fn + 5);
                 else if (!strncmp(fn, "counter=", 8)) load_int(&pr0->counter, fn + 8);
-#ifndef DAWN_NO_OUTPUT
                 else if (!strncmp(fn, "deny=", 5)) load_int(&pr0->deny_counter, fn + 5);
                 else if (!strncmp(fn, "max_rate=", 9)) load_u8(&pr0->max_supp_datarate, fn + 9);
                 else if (!strncmp(fn, "min_rate=", 9)) load_u8(&pr0->min_supp_datarate, fn + 9);
-#endif
                 else if (!strncmp(fn, "rcpi=", 5)) load_u32(&pr0->rcpi, fn + 5);
                 else if (!strncmp(fn, "rsni=", 5)) load_u32(&pr0->rsni, fn + 5);
                 else {
@@ -936,11 +935,9 @@ static int consume_actions(int argc, char* argv[], int harness_verbosity)
                         pr0->vht_capabilities = 0;
                         pr0->time = faketime;
                         pr0->counter = 0;
-#ifndef DAWN_NO_OUTPUT
                         pr0->deny_counter = 0;
                         pr0->max_supp_datarate = 0;
                         pr0->min_supp_datarate = 0;
-#endif
                         pr0->rcpi = 0;
                         pr0->rsni = 0;
 
@@ -1072,6 +1069,9 @@ static int consume_actions(int argc, char* argv[], int harness_verbosity)
                     ap* ap_entry = ap_array_get_ap(pr0->bssid_addr, NULL);
 
                     int this_metric = eval_probe_metric(pr0, ap_entry);
+                    dawnlog_info("Score: %d of:\n", this_metric);
+                    print_probe_entry(DAWNLOG_DEBUG, pr0);
+
                     printf("eval_probe_metric: Returned %d\n", this_metric);
                 }
 
@@ -1183,6 +1183,8 @@ int main(int argc, char* argv[])
 
     int ret = 0;
     int harness_verbosity = 1;
+
+    dawnlog_dest(DAWNLOG_DEST_STDIO); // Send messages to stderr / stdout
 
     printf("DAWN datastorage.c test harness...\n\n");
 

--- a/src/test/test_storage.c
+++ b/src/test/test_storage.c
@@ -429,7 +429,17 @@ static int consume_actions(int argc, char* argv[], int harness_verbosity)
             args_required = 1;
 
             char* leaky = dawn_malloc(10);
-            strcpy(leaky, "LEAKED"); // Force use of memory to avoid unused error
+            strcpy(leaky, "TRACKED"); // Force use of memory to avoid unused error
+
+            leaky = malloc(10);
+            strcpy(leaky, "UNTRACKED"); // Force use of memory to avoid unused error
+        }
+        else if (strcmp(*argv, "segv") == 0)
+        {
+            args_required = 1;
+
+            char *badpointer = 0;
+            *badpointer = 0;
         }
         else if (strcmp(*argv, "memaudit") == 0)
         {

--- a/src/utils/dawn_iwinfo.c
+++ b/src/utils/dawn_iwinfo.c
@@ -103,12 +103,10 @@ int get_bandwidth_iwinfo(struct dawn_mac client_addr, float *rx_rate, float *tx_
 
     int sucess = 0;
 
-    while ((entry = readdir(dirp)) != NULL) {
+    while (!sucess && ((entry = readdir(dirp)) != NULL)) {
         if (entry->d_type == DT_SOCK) {
-            if (get_bandwidth(entry->d_name, client_addr, rx_rate, tx_rate)) {
-                sucess = 1;
-                break;
-            }
+            dawnlog_debug("[BANDWIDTH INFO] Trying %s\n", entry->d_name);
+            sucess = get_bandwidth(entry->d_name, client_addr, rx_rate, tx_rate);
         }
     }
     closedir(dirp);
@@ -116,35 +114,34 @@ int get_bandwidth_iwinfo(struct dawn_mac client_addr, float *rx_rate, float *tx_
 }
 
 int get_bandwidth(const char *ifname, struct dawn_mac client_addr, float *rx_rate, float *tx_rate) {
+    int ret = 0;
 
-    int i, len;
-    char buf[IWINFO_BUFSIZE];
-    struct iwinfo_assoclist_entry *e;
-    const struct iwinfo_ops *iw;
-    if (strcmp(ifname, "global") == 0)
-        return 0;
-    iw = iwinfo_backend(ifname);
+    if (strcmp(ifname, "global") != 0)
+    {
+        const struct iwinfo_ops* iw = iwinfo_backend(ifname);
 
-    if (iw->assoclist(ifname, buf, &len)) {
-        iwinfo_finish();
-        return 0;
-    } else if (len <= 0) {
-        iwinfo_finish();
-        return 0;
-    }
+        char buf[IWINFO_BUFSIZE];
+        int len;
+        if (iw->assoclist(ifname, buf, &len) == 0 && len > 0)
+        {
+            struct iwinfo_assoclist_entry* e = (struct iwinfo_assoclist_entry*)buf;
+            for (int i = 0; ret == 0 && i < len; i += sizeof(struct iwinfo_assoclist_entry)) {
 
-    for (i = 0; i < len; i += sizeof(struct iwinfo_assoclist_entry)) {
-        e = (struct iwinfo_assoclist_entry *) &buf[i];
+                if (mac_is_equal(client_addr.u8, e->mac)) {
+                    *rx_rate = e->rx_rate.rate / 1000.0;
+                    *tx_rate = e->tx_rate.rate / 1000.0;
 
-        if (mac_is_equal(client_addr.u8, e->mac)) {
-            *rx_rate = e->rx_rate.rate / 1000;
-            *tx_rate = e->tx_rate.rate / 1000;
-            iwinfo_finish();
-            return 1;
+                    ret = 1;
+                }
+
+                e++;
+            }
         }
+
+        iwinfo_finish();
     }
-    iwinfo_finish();
-    return 0;
+
+    return ret;
 }
 
 int get_rssi_iwinfo(struct dawn_mac client_addr) {

--- a/src/utils/dawn_iwinfo.c
+++ b/src/utils/dawn_iwinfo.c
@@ -24,11 +24,6 @@ int get_bandwidth(const char *ifname, struct dawn_mac client_addr, float *rx_rat
 int compare_essid_iwinfo(struct dawn_mac bssid_addr, struct dawn_mac bssid_addr_to_compare) {
     const struct iwinfo_ops *iw;
 
-    char mac_buf[20];
-    char mac_buf_to_compare[20];
-    sprintf(mac_buf, MACSTR, MAC2STR(bssid_addr.u8));
-    sprintf(mac_buf_to_compare, MACSTR, MAC2STR(bssid_addr_to_compare.u8));
-
     DIR *dirp;
     struct dirent *entry;
     dirp = opendir(hostapd_dir_glob);  // error handling?
@@ -50,10 +45,14 @@ int compare_essid_iwinfo(struct dawn_mac bssid_addr, struct dawn_mac bssid_addr_
 
             iw = iwinfo_backend(entry->d_name);
 
+            // FIXME: Try to reduce string conversion and comparison here by using byte array compares
             // TODO: Magic number
             static char buf_bssid[18] = {0};
             if (iw->bssid(entry->d_name, buf_bssid))
                 snprintf(buf_bssid, sizeof(buf_bssid), "00:00:00:00:00:00");
+
+            char mac_buf[20];
+            sprintf(mac_buf, MACSTR, MAC2STR(bssid_addr.u8));
 
             if (strcmp(mac_buf, buf_bssid) == 0) {
 
@@ -61,6 +60,9 @@ int compare_essid_iwinfo(struct dawn_mac bssid_addr, struct dawn_mac bssid_addr_
                     memset(buf_essid, 0, sizeof(buf_essid));
                 essid = buf_essid;
             }
+
+            char mac_buf_to_compare[20];
+            sprintf(mac_buf_to_compare, MACSTR, MAC2STR(bssid_addr_to_compare.u8));
 
             if (strcmp(mac_buf_to_compare, buf_bssid) == 0) {
                 if (iw->ssid(entry->d_name, buf_essid_to_compare))

--- a/src/utils/dawn_iwinfo.c
+++ b/src/utils/dawn_iwinfo.c
@@ -33,7 +33,7 @@ int compare_essid_iwinfo(struct dawn_mac bssid_addr, struct dawn_mac bssid_addr_
     struct dirent *entry;
     dirp = opendir(hostapd_dir_glob);  // error handling?
     if (!dirp) {
-        fprintf(stderr, "[COMPARE ESSID] Failed to open %s\n", hostapd_dir_glob);
+        dawnlog_error("[COMPARE ESSID] Failed to open %s\n", hostapd_dir_glob);
         return 0;
     }
 
@@ -72,6 +72,8 @@ int compare_essid_iwinfo(struct dawn_mac bssid_addr, struct dawn_mac bssid_addr_
     }
     closedir(dirp);
 
+    dawnlog_debug("Comparing: %s with %s\n", essid, essid_to_compare);
+
     if (essid == NULL || essid_to_compare == NULL) {
         return -1;
     }
@@ -89,8 +91,12 @@ int get_bandwidth_iwinfo(struct dawn_mac client_addr, float *rx_rate, float *tx_
     struct dirent *entry;
     dirp = opendir(hostapd_dir_glob);  // error handling?
     if (!dirp) {
-        fprintf(stderr, "[BANDWIDTH INFO] Failed to open %s\n", hostapd_dir_glob);
+        dawnlog_error("[BANDWIDTH INFO] Failed to open %s\n", hostapd_dir_glob);
         return 0;
+    }
+    else
+    {
+        dawnlog_debug("[BANDWIDTH INFO] Opened %s\n", hostapd_dir_glob);
     }
 
     int sucess = 0;
@@ -145,7 +151,7 @@ int get_rssi_iwinfo(struct dawn_mac client_addr) {
     struct dirent *entry;
     dirp = opendir(hostapd_dir_glob);  // error handling?
     if (!dirp) {
-        fprintf(stderr, "[RSSI INFO] No hostapd sockets!\n");
+        dawnlog_error("[RSSI INFO] No hostapd sockets!\n");
         return INT_MIN;
     }
 
@@ -173,15 +179,11 @@ int get_rssi(const char *ifname, struct dawn_mac client_addr) {
     iw = iwinfo_backend(ifname);
 
     if (iw->assoclist(ifname, buf, &len)) {
-#ifndef DAWN_NO_OUTPUT
-        fprintf(stdout, "No information available\n");
-#endif
+        dawnlog_warning("No information available\n");
         iwinfo_finish();
         return INT_MIN;
     } else if (len <= 0) {
-#ifndef DAWN_NO_OUTPUT
-        fprintf(stdout, "No station connected\n");
-#endif
+        dawnlog_warning("No station connected\n");
         iwinfo_finish();
         return INT_MIN;
     }
@@ -205,7 +207,7 @@ int get_expected_throughput_iwinfo(struct dawn_mac client_addr) {
     struct dirent *entry;
     dirp = opendir(hostapd_dir_glob);  // error handling?
     if (!dirp) {
-        fprintf(stderr, "[RSSI INFO] Failed to open dir:%s\n", hostapd_dir_glob);
+        dawnlog_error("[RSSI INFO] Failed to open dir:%s\n", hostapd_dir_glob);
         return INT_MIN;
     }
 
@@ -233,15 +235,11 @@ int get_expected_throughput(const char *ifname, struct dawn_mac client_addr) {
     iw = iwinfo_backend(ifname);
 
     if (iw->assoclist(ifname, buf, &len)) {
-#ifndef DAWN_NO_OUTPUT
-        fprintf(stdout, "No information available\n");
-#endif
+        dawnlog_warning("No information available\n");
         iwinfo_finish();
         return INT_MIN;
     } else if (len <= 0) {
-#ifndef DAWN_NO_OUTPUT
-        fprintf(stdout, "No station connected\n");
-#endif
+        dawnlog_warning("No station connected\n");
         iwinfo_finish();
         return INT_MIN;
     }
@@ -310,13 +308,13 @@ int get_channel_utilization(const char *ifname, uint64_t *last_channel_time, uin
 
     if (iw->survey(ifname, buf, &len))
     {
-        fprintf(stderr, "Survey not possible!\n\n");
+        dawnlog_warning("Survey not possible!\n");
         iwinfo_finish();
         return 0;
     }
     else if (len <= 0)
     {
-        fprintf(stderr, "No survey results\n\n");
+        dawnlog_warning("No survey results\n");
         iwinfo_finish();
         return 0;
     }
@@ -352,6 +350,7 @@ int support_ht(const char *ifname) {
 
     if (iw->htmodelist(ifname, &htmodes))
     {
+        dawnlog_debug("No HT mode information available\n");
         iwinfo_finish();
         return 0;
     }
@@ -371,6 +370,7 @@ int support_vht(const char *ifname) {
 
     if (iw->htmodelist(ifname, &htmodes))
     {
+        dawnlog_error("No VHT mode information available\n");
         iwinfo_finish();
         return 0;
     }

--- a/src/utils/dawn_uci.c
+++ b/src/utils/dawn_uci.c
@@ -25,6 +25,8 @@ static void set_if_present_int(int *ret, struct uci_section *s, const char* opti
 
 void uci_get_hostname(char* hostname)
 {
+    dawnlog_debug_func("Entering...");
+
     char path[]= "system.@system[0].hostname";
     struct  uci_ptr ptr;
     struct  uci_context *c = uci_alloc_context();
@@ -80,6 +82,8 @@ struct time_config_s uci_get_time_config() {
         .update_beacon_reports = 20,
     };
 
+    dawnlog_debug_func("Entering...");
+
     struct uci_element *e;
     uci_foreach_element(&uci_pkg->sections, e)
     {
@@ -97,6 +101,43 @@ struct time_config_s uci_get_time_config() {
             DAWN_SET_CONFIG_TIME(ret, s, update_beacon_reports);
             return ret;
         }
+    }
+
+    return ret;
+}
+
+struct local_config_s uci_get_local_config() {
+    struct local_config_s ret = {
+        .loglevel = 0,
+    };
+
+    dawnlog_debug_func("Entering...");
+
+    struct uci_element* e;
+    uci_foreach_element(&uci_pkg->sections, e)
+    {
+        struct uci_section* s = uci_to_section(e);
+
+        if (strcmp(s->type, "local") == 0) {
+            DAWN_SET_CONFIG_INT(ret, s, loglevel);
+        }
+    }
+
+    switch (ret.loglevel)
+    {
+    case 3:
+        dawnlog_minlevel(DAWNLOG_DEBUG);
+        break;
+    case 2:
+        dawnlog_minlevel(DAWNLOG_TRACE);
+        break;
+    case 1:
+        dawnlog_minlevel(DAWNLOG_INFO);
+        break;
+    case 0:
+    default:
+        dawnlog_minlevel(DAWNLOG_ALWAYS);
+        break;
     }
 
     return ret;
@@ -123,6 +164,8 @@ static int parse_rrm_mode(int *rrm_mode_order, const char *mode_string) {
     int len, mode_val;
     int mask = 0, order = 0, pos = 0;
 
+    dawnlog_debug_func("Entering...");
+
     if (!mode_string)
         mode_string = DEFAULT_RRM_MODE_ORDER;
     len = strlen(mode_string);
@@ -141,15 +184,17 @@ static int parse_rrm_mode(int *rrm_mode_order, const char *mode_string) {
 
 
 static struct mac_entry_s *insert_neighbor_mac(struct mac_entry_s *head, const char* mac) {
+    dawnlog_debug_func("Entering...");
+
     struct mac_entry_s *new;
 
     if (!(new = dawn_malloc(sizeof (struct mac_entry_s)))) {
-        fprintf(stderr, "Warning: Failed to create neighbor entry for '%s'\n", mac);
+        dawnlog_error("Failed to allocate neighbor entry for '%s'\n", mac);
         return head;
     }
     memset(new, 0, sizeof (struct mac_entry_s));
     if (hwaddr_aton(mac, new->mac.u8) != 0) {
-        fprintf(stderr, "Warning: Failed to parse MAC from '%s'\n", mac);
+        dawnlog_error("Failed to parse MAC from '%s'\n", mac);
         dawn_free(new);
         return head;
     }
@@ -159,6 +204,8 @@ static struct mac_entry_s *insert_neighbor_mac(struct mac_entry_s *head, const c
 
 static void free_neighbor_mac_list(struct mac_entry_s *list) {
     struct mac_entry_s *ptr = list;
+    dawnlog_debug_func("Entering...");
+
     while (list) {
         ptr = list;
         list = list->next_mac;
@@ -170,6 +217,8 @@ static struct mac_entry_s* uci_lookup_mac_list(struct uci_option *o) {
     struct uci_element *e;
     struct mac_entry_s *head = NULL;
     char *str;
+
+    dawnlog_debug_func("Entering...");
 
     if (o == NULL)
         return NULL;
@@ -195,6 +244,8 @@ static struct mac_entry_s* uci_lookup_mac_list(struct uci_option *o) {
 static struct uci_section *uci_find_metric_section(const char *name) {
     struct uci_section *s;
     struct uci_element *e;
+
+    dawnlog_debug_func("Entering...");
 
     uci_foreach_element(&uci_pkg->sections, e) {
         s = uci_to_section(e);
@@ -257,9 +308,9 @@ struct probe_metric_s uci_get_dawn_metric() {
 
     if (!(global_s = uci_find_metric_section("global"))) {
         if (!(global_s = uci_find_metric_section(NULL))) {
-            fprintf(stderr, "Warning: config metric global section not found! Using defaults.\n");
+            dawnlog_warning("config metric global section not found! Using defaults.\n");
         } else {
-            fprintf(stderr, "Warning: config metric global section not found. "
+            dawnlog_warning("config metric global section not found. "
                             "Using first unnamed config metric.\n"
                             "Consider naming a 'global' metric section to avoid ambiguity.\n");
         }
@@ -325,6 +376,8 @@ struct network_config_s uci_get_dawn_network() {
         .bandwidth = -1,
     };
 
+    dawnlog_debug_func("Entering...");
+
     struct uci_element *e;
     uci_foreach_element(&uci_pkg->sections, e)
     {
@@ -362,6 +415,8 @@ struct network_config_s uci_get_dawn_network() {
 }
 
 bool uci_get_dawn_hostapd_dir() {
+    dawnlog_debug_func("Entering...");
+
     struct uci_element *e;
     uci_foreach_element(&uci_pkg->sections, e)
     {
@@ -377,6 +432,8 @@ bool uci_get_dawn_hostapd_dir() {
 }
 
 bool uci_get_dawn_sort_order() {
+    dawnlog_debug_func("Entering...");
+
     struct uci_element *e;
     uci_foreach_element(&uci_pkg->sections, e)
     {
@@ -393,6 +450,8 @@ bool uci_get_dawn_sort_order() {
 
 int uci_reset()
 {
+    dawnlog_debug_func("Entering...");
+
     struct uci_context *ctx = uci_ctx;
 
     if (!ctx) {
@@ -410,6 +469,8 @@ int uci_reset()
 }
 
 int uci_init() {
+    dawnlog_debug_func("Entering...");
+
     struct uci_context *ctx = uci_ctx;
 
     if (!ctx) {
@@ -439,6 +500,8 @@ int uci_init() {
 }
 
 int uci_clear() {
+    dawnlog_debug_func("Entering...");
+
     for (int band = 0; band < __DAWN_BAND_MAX; band++)
         free_neighbor_mac_list(dawn_metric.neighbors[band]);
 
@@ -456,6 +519,8 @@ int uci_clear() {
 
 int uci_set_network(char* uci_cmd)
 {
+    dawnlog_debug_func("Entering...");
+
     struct uci_ptr ptr;
     int ret = UCI_OK;
     struct uci_context *ctx  = uci_ctx;
@@ -480,7 +545,7 @@ int uci_set_network(char* uci_cmd)
     }
 
     if (uci_commit(ctx, &ptr.p, 0) != UCI_OK) {
-        fprintf(stderr, "Failed to commit UCI cmd: %s\n", uci_cmd);
+        dawnlog_error("Failed to commit UCI cmd: %s\n", uci_cmd);
     }
 
     return ret;

--- a/src/utils/dawn_uci.c
+++ b/src/utils/dawn_uci.c
@@ -308,15 +308,18 @@ struct probe_metric_s uci_get_dawn_metric() {
     struct uci_section *global_s, *band_s[__DAWN_BAND_MAX];
     struct uci_option *global_neighbors = NULL, *neighbors;
 
-    if (!(global_s = uci_find_metric_section("global"))) {
-        if (!(global_s = uci_find_metric_section(NULL))) {
-            dawnlog_warning("config metric global section not found! Using defaults.\n");
-        } else {
-            dawnlog_warning("config metric global section not found. "
-                            "Using first unnamed config metric.\n"
-                            "Consider naming a 'global' metric section to avoid ambiguity.\n");
-        }
-    }
+    dawnlog_debug_func("Entering...");
+
+    global_s = uci_find_metric_section("global");
+
+    if (!global_s && (global_s = uci_find_metric_section(NULL)))
+        dawnlog_warning("config metric global section not found. "
+            "Using first unnamed config metric.\n"
+            "Consider naming a 'global' metric section to avoid ambiguity.\n");
+
+    if (!global_s)
+        dawnlog_warning("config metric global section not found! Using defaults.\n");
+
     if (global_s) {
         // True global configuration
         DAWN_SET_CONFIG_INT(ret, global_s, kicking);

--- a/src/utils/dawn_uci.c
+++ b/src/utils/dawn_uci.c
@@ -186,9 +186,9 @@ static int parse_rrm_mode(int *rrm_mode_order, const char *mode_string) {
 static struct mac_entry_s *insert_neighbor_mac(struct mac_entry_s *head, const char* mac) {
     dawnlog_debug_func("Entering...");
 
-    struct mac_entry_s *new;
+    struct mac_entry_s *new = dawn_malloc(sizeof(struct mac_entry_s));
 
-    if (!(new = dawn_malloc(sizeof (struct mac_entry_s)))) {
+    if (new == NULL) {
         dawnlog_error("Failed to allocate neighbor entry for '%s'\n", mac);
         return head;
     }
@@ -196,6 +196,7 @@ static struct mac_entry_s *insert_neighbor_mac(struct mac_entry_s *head, const c
     if (hwaddr_aton(mac, new->mac.u8) != 0) {
         dawnlog_error("Failed to parse MAC from '%s'\n", mac);
         dawn_free(new);
+        new = NULL;
         return head;
     }
     new->next_mac = head;
@@ -210,13 +211,14 @@ static void free_neighbor_mac_list(struct mac_entry_s *list) {
         ptr = list;
         list = list->next_mac;
         dawn_free(ptr);
+        ptr = NULL;
     }
 }
 
 static struct mac_entry_s* uci_lookup_mac_list(struct uci_option *o) {
-    struct uci_element *e;
+    struct uci_element *e = NULL;
     struct mac_entry_s *head = NULL;
-    char *str;
+    char* str = NULL;
 
     dawnlog_debug_func("Entering...");
 
@@ -337,6 +339,7 @@ struct probe_metric_s uci_get_dawn_metric() {
                                            uci_lookup_option_string(uci_ctx, global_s, "rrm_mode"));
         global_neighbors = uci_lookup_option(uci_ctx, global_s, "neighbors");
     }
+
     for (int band = 0; band < __DAWN_BAND_MAX; band++) {
         band_s[band] = uci_find_metric_section(band_config_name[band]);
         neighbors = band_s[band] ? uci_lookup_option(uci_ctx, band_s[band], "neighbors") : NULL;

--- a/src/utils/mac_utils.c
+++ b/src/utils/mac_utils.c
@@ -48,17 +48,10 @@ int hwaddr_aton(const char* txt, uint8_t* addr) {
 
 void write_mac_to_file(char* path, struct dawn_mac addr) {
     FILE* f = fopen(path, "a");
-    if (f == NULL) {
+    if (f == NULL)
         dawnlog_error("Error opening mac file!\n");
-
-        // TODO: Should this be an exit()?
-        exit(1);
-    }
-
-    char mac_buf[20];
-    sprintf(mac_buf, MACSTR, MAC2STR(addr.u8));
-
-    fprintf(f, "%s\n", mac_buf);
+    else
+        fprintf(f, MACSTR "\n", MAC2STR(addr.u8));
 
     fclose(f);
 }

--- a/src/utils/mac_utils.c
+++ b/src/utils/mac_utils.c
@@ -49,7 +49,7 @@ int hwaddr_aton(const char* txt, uint8_t* addr) {
 void write_mac_to_file(char* path, struct dawn_mac addr) {
     FILE* f = fopen(path, "a");
     if (f == NULL) {
-        fprintf(stderr, "Error opening mac file!\n");
+        dawnlog_error("Error opening mac file!\n");
 
         // TODO: Should this be an exit()?
         exit(1);

--- a/src/utils/memory_utils.c
+++ b/src/utils/memory_utils.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <inttypes.h>
 
+#include "utils.h"
 #include "memory_utils.h"
 
 #define DAWN_MEM_FILENAME_LEN 20
@@ -73,7 +74,7 @@ void* dawn_memory_register(enum dawn_memop type, char* file, int line, size_t si
         type_c = 'X';
         break;
     default:
-        printf("mem-audit: Unexpected memory op tag!\n");
+        dawnlog_warning("mem-audit: Unexpected memory op tag!\n");
         break;
     }
 
@@ -84,7 +85,7 @@ void* dawn_memory_register(enum dawn_memop type, char* file, int line, size_t si
 
     if (*ipos != NULL && (*ipos)->ptr == ptr)
     {
-        printf("mem-audit: attempting to register memory already registered (%c@%s:%d)...\n", type_c, file, line);
+        dawnlog_warning("mem-audit: attempting to register memory already registered (%c@%s:%d)...\n", type_c, file, line);
     }
     else
     {
@@ -92,7 +93,7 @@ void* dawn_memory_register(enum dawn_memop type, char* file, int line, size_t si
 
         if (this_log == NULL)
         {
-            printf("mem-audit: Oh the irony! malloc() failed in dawn_memory_register()!\n");
+           dawnlog_warning("mem-audit: Oh the irony! malloc() failed in dawn_memory_register()!\n");
         }
         else
         {
@@ -140,7 +141,7 @@ char type_c = '?';
         type_c = 'R';
         break;
     default:
-        printf("mem-audit: Unexpected memory op tag!\n");
+        dawnlog_warning("mem-audit: Unexpected memory op tag!\n");
         break;
     }
 
@@ -152,7 +153,7 @@ char type_c = '?';
     }
     else
     {
-        printf("mem-audit: Releasing (%c) memory we hadn't registered (%s:%d)...\n", type_c, file, line);
+        dawnlog_warning("mem-audit: Releasing (%c) memory we hadn't registered (%s:%d)...\n", type_c, file, line);
     }
 
     return;
@@ -171,10 +172,10 @@ void dawn_memory_audit()
 {
 size_t    total = 0;
 
-     printf("mem-audit: Currently recorded allocations...\n");
+    dawnlog_always("mem-audit: Currently recorded allocations...\n");
      for (struct mem_list* mem = mem_base; mem != NULL; mem = mem->next_mem)
      {
-         printf("mem-audit: %8" PRIu64 "=%c - %s@%d: %zu\n", mem->ref, mem->type, mem->file, mem->line, mem->size);
+        dawnlog_always("mem-audit: %8" PRIu64 "=%c - %s@%d: %zu\n", mem->ref, mem->type, mem->file, mem->line, mem->size);
          total += mem->size;
      }
 
@@ -185,5 +186,5 @@ size_t    total = 0;
          suffix = "kbytes";
      }
 
-     printf("mem-audit: [End of list: %zu %s]\n", total, suffix);
+    dawnlog_always("mem-audit: [End of list: %zu %s]\n", total, suffix);
 }

--- a/src/utils/msghandler.c
+++ b/src/utils/msghandler.c
@@ -163,18 +163,21 @@ probe_entry *parse_to_probe_req(struct blob_attr* msg) {
     if (hwaddr_aton(blobmsg_data(tb[PROB_BSSID_ADDR]), prob_req->bssid_addr.u8))
     {
         dawn_free(prob_req);
+        prob_req = NULL;
         return NULL;
     }
 
     if (hwaddr_aton(blobmsg_data(tb[PROB_CLIENT_ADDR]), prob_req->client_addr.u8))
     {
         dawn_free(prob_req);
+        prob_req = NULL;
         return NULL;
     }
 
     if (hwaddr_aton(blobmsg_data(tb[PROB_TARGET_ADDR]), prob_req->target_addr.u8))
     {
         dawn_free(prob_req);
+        prob_req = NULL;
         return NULL;
     }
 
@@ -259,6 +262,7 @@ int handle_network_msg(char* msg) {
     dawnlog_debug_func("Entering...");
 
     blob_buf_init(&network_buf, 0);
+    // dawn_regmem(&network_buf);
     blobmsg_add_json_from_string(&network_buf, msg);
 
     blobmsg_parse(network_policy, __NETWORK_MAX, tb, blob_data(network_buf.head), blob_len(network_buf.head));
@@ -273,6 +277,7 @@ int handle_network_msg(char* msg) {
     dawnlog_debug("Network Method new: %s : %s\n", method, msg);
 
     blob_buf_init(&data_buf, 0);
+    // dawn_regmem(&data_buf);
     blobmsg_add_json_from_string(&data_buf, data);
 
     if (!data_buf.head) {
@@ -299,6 +304,7 @@ int handle_network_msg(char* msg) {
             {
                 // insert found an existing entry, rather than linking in our new one
                 dawn_free(entry);
+                entry = NULL;
             }
         }
     }
@@ -336,6 +342,12 @@ int handle_network_msg(char* msg) {
     {
         dawnlog_warning("No method found for: %s\n", method);
     }
+
+    blob_buf_free(&data_buf);
+    // dawn_unregmem(&data_buf);
+
+    blob_buf_free(&network_buf);
+    // dawn_unregmem(&network_buf);
 
     return 0;
 }
@@ -427,7 +439,11 @@ dump_client(struct blob_attr** tb, struct dawn_mac client_addr, const char* bssi
     pthread_mutex_lock(&client_array_mutex);
     // If entry was akraedy in list it won't be added, so free memorY
     if (client_entry != insert_client_to_array(client_entry, time(0)))
+    {
         dawn_free(client_entry);
+        client_entry = NULL;
+    }
+
     pthread_mutex_unlock(&client_array_mutex);
 }
 

--- a/src/utils/msghandler.c
+++ b/src/utils/msghandler.c
@@ -133,6 +133,8 @@ static int handle_uci_config(struct blob_attr* msg);
 int parse_to_hostapd_notify(struct blob_attr* msg, hostapd_notify_entry* notify_req) {
     struct blob_attr* tb[__HOSTAPD_NOTIFY_MAX];
 
+    dawnlog_debug_func("Entering...");
+
     blobmsg_parse(hostapd_notify_policy, __HOSTAPD_NOTIFY_MAX, tb, blob_data(msg), blob_len(msg));
 
     if (hwaddr_aton(blobmsg_data(tb[HOSTAPD_NOTIFY_BSSID_ADDR]), notify_req->bssid_addr.u8))
@@ -147,10 +149,12 @@ int parse_to_hostapd_notify(struct blob_attr* msg, hostapd_notify_entry* notify_
 probe_entry *parse_to_probe_req(struct blob_attr* msg) {
     struct blob_attr* tb[__PROB_MAX];
 
+    dawnlog_debug_func("Entering...");
+
     probe_entry* prob_req = dawn_malloc(sizeof(probe_entry));
     if (prob_req == NULL)
     {
-        fprintf(stderr, "dawn_malloc of probe_entry failed!\n");
+        dawnlog_error("dawn_malloc of probe_entry failed!\n");
         return NULL;
     }
 
@@ -220,6 +224,8 @@ int handle_deauth_req(struct blob_attr* msg) {
     hostapd_notify_entry notify_req;
     parse_to_hostapd_notify(msg, &notify_req);
 
+    dawnlog_debug_func("Entering...");
+
     pthread_mutex_lock(&client_array_mutex);
 
     client* client_entry = client_array_get_client(notify_req.client_addr);
@@ -228,10 +234,14 @@ int handle_deauth_req(struct blob_attr* msg) {
 
     pthread_mutex_unlock(&client_array_mutex);
 
+    dawnlog_debug("[WC] Deauth: %s\n", "deauth");
+
     return 0;
 }
 
 static int handle_set_probe(struct blob_attr* msg) {
+
+    dawnlog_debug_func("Entering...");
 
     hostapd_notify_entry notify_req;
     parse_to_hostapd_notify(msg, &notify_req);
@@ -246,6 +256,8 @@ int handle_network_msg(char* msg) {
     char* method;
     char* data;
 
+    dawnlog_debug_func("Entering...");
+
     blob_buf_init(&network_buf, 0);
     blobmsg_add_json_from_string(&network_buf, msg);
 
@@ -258,18 +270,18 @@ int handle_network_msg(char* msg) {
     method = blobmsg_data(tb[NETWORK_METHOD]);
     data = blobmsg_data(tb[NETWORK_DATA]);
 
-#ifndef DAWN_NO_OUTPUT
-    printf("Network Method new: %s : %s\n", method, msg);
-#endif
+    dawnlog_debug("Network Method new: %s : %s\n", method, msg);
 
     blob_buf_init(&data_buf, 0);
     blobmsg_add_json_from_string(&data_buf, data);
 
     if (!data_buf.head) {
+        dawnlog_warning("Data header not formed!");
         return -1;
     }
 
     if (blob_len(data_buf.head) <= 0) {
+        dawnlog_warning("Data header invalid length!");
         return -1;
     }
 
@@ -294,15 +306,11 @@ int handle_network_msg(char* msg) {
         parse_to_clients(data_buf.head, 0, 0);
     }
     else if (strncmp(method, "deauth", 5) == 0) {
-#ifndef DAWN_NO_OUTPUT
-        printf("METHOD DEAUTH\n");
-#endif
+        dawnlog_debug("METHOD DEAUTH\n");
         handle_deauth_req(data_buf.head);
     }
     else if (strncmp(method, "setprobe", 5) == 0) {
-#ifndef DAWN_NO_OUTPUT
-        printf("HANDLING SET PROBE!\n");
-#endif
+        dawnlog_debug("HANDLING SET PROBE!\n");
         handle_set_probe(data_buf.head);
     }
     else if (strncmp(method, "addmac", 5) == 0) {
@@ -312,25 +320,21 @@ int handle_network_msg(char* msg) {
         parse_add_mac_to_file(data_buf.head);
     }
     else if (strncmp(method, "uci", 2) == 0) {
-#ifndef DAWN_NO_OUTPUT
-        printf("HANDLING UCI!\n");
-#endif
+        dawnlog_debug("HANDLING UCI!\n");
         handle_uci_config(data_buf.head);
     }
     else if (strncmp(method, "beacon-report", 12) == 0) {
         // TODO: Check beacon report stuff
 
-        //printf("HANDLING BEACON REPORT NETWORK!\n");
-        //printf("The Method for beacon-report is: %s\n", method);
+        dawnlog_debug("HANDLING BEACON REPORT NETWORK!\n");
+        dawnlog_debug("The Method for beacon-report is: %s\n", method);
         // ignore beacon reports send via network!, use probe functions for it
         //probe_entry entry; // for now just stay at probe entry stuff...
         //parse_to_beacon_rep(data_buf.head, &entry, true);
     }
     else
     {
-#ifndef DAWN_NO_OUTPUT
-        printf("No method fonud for: %s\n", method);
-#endif
+        dawnlog_warning("No method found for: %s\n", method);
     }
 
     return 0;
@@ -339,8 +343,10 @@ int handle_network_msg(char* msg) {
 static uint8_t
 dump_rrm_data(struct blob_attr* head)
 {
+    dawnlog_debug_func("Entering...");
+
     if (blob_id(head) != BLOBMSG_TYPE_INT32) {
-        fprintf(stderr, "wrong type of rrm array.\n");
+        dawnlog_error("wrong type of rrm array.\n");
         return 0;
     }
     return (uint8_t)blobmsg_get_u32(head);
@@ -350,6 +356,8 @@ dump_rrm_data(struct blob_attr* head)
 static void
 dump_client(struct blob_attr** tb, struct dawn_mac client_addr, const char* bssid_addr, uint32_t freq, uint8_t ht_supported,
     uint8_t vht_supported) {
+    dawnlog_debug_func("Entering...");
+
     client *client_entry = dawn_malloc(sizeof(struct client_s));
     if (client_entry == NULL)
     {
@@ -430,6 +438,8 @@ dump_client_table(struct blob_attr* head, int len, const char* bssid_addr, uint3
     struct blobmsg_hdr* hdr;
     int station_count = 0;
 
+    dawnlog_debug_func("Entering...");
+
     __blob_for_each_attr(attr, head, len)
     {
         hdr = blob_data(attr);
@@ -452,6 +462,8 @@ dump_client_table(struct blob_attr* head, int len, const char* bssid_addr, uint3
 
 int parse_to_clients(struct blob_attr* msg, int do_kick, uint32_t id) {
     struct blob_attr* tb[__CLIENT_TABLE_MAX];
+
+    dawnlog_debug_func("Entering...");
 
     if (!msg) {
         return -1;
@@ -682,12 +694,14 @@ static const struct blobmsg_policy uci_times_policy[__UCI_TIMES_MAX] = {
 
 static int handle_uci_config(struct blob_attr* msg) {
 
+    dawnlog_debug_func("Entering...");
+
     struct blob_attr* tb[__UCI_TABLE_MAX];
     blobmsg_parse(uci_table_policy, __UCI_TABLE_MAX, tb, blob_data(msg), blob_len(msg));
 
     const char *version_string = blobmsg_get_string(tb[UCI_CONFIG_VERSION]);
     if (version_string == NULL || strcmp(version_string, DAWN_CONFIG_VERSION)) {
-        fprintf(stderr, "Ignoring network config message with incompatible version string '%s'.\n",
+        dawnlog_warning("Ignoring network config message with incompatible version string '%s'.\n",
                 version_string ? : "");
         return -1;
     }
@@ -768,7 +782,7 @@ static int handle_uci_config(struct blob_attr* msg) {
                 break;
         }
         if (band == __DAWN_BAND_MAX) {
-            fprintf(stderr, "handle_uci_config: Warning: unknown band '%s'.\n", band_name);
+            dawnlog_warning("handle_uci_config: unknown band '%s'.\n", band_name);
             continue;  // Should we write the metrics of an unknown band to the config file?
         }
 

--- a/src/utils/ubus.c
+++ b/src/utils/ubus.c
@@ -243,38 +243,6 @@ void blobmsg_add_macaddr(struct blob_buf *buf, const char *name, const struct da
     blobmsg_add_string_buffer(buf);
 }
 
-// TODO: Is it worth having this function?  Just inline the right bits at each caller?
-static int decide_function(probe_entry *prob_req, int req_type) {
-    if (mac_in_maclist(prob_req->client_addr)) {
-        return 1;
-    }
-
-    if (prob_req->counter < dawn_metric.min_probe_count) {
-        return 0;
-    }
-
-    if (req_type == REQ_TYPE_PROBE && dawn_metric.eval_probe_req <= 0) {
-        return 1;
-    }
-
-    if (req_type == REQ_TYPE_AUTH && dawn_metric.eval_auth_req <= 0) {
-        return 1;
-    }
-
-    if (req_type == REQ_TYPE_ASSOC && dawn_metric.eval_assoc_req <= 0) {
-        return 1;
-    }
-
-    // TODO: Bug?  This results in copious "Neigbor-Report is NULL" messages!
-    // find own probe entry and calculate score
-    ap* this_ap = ap_array_get_ap(prob_req->bssid_addr, prob_req->ssid);
-    if (this_ap != NULL && better_ap_available(this_ap, prob_req->client_addr, NULL)) {
-        return 0;
-    }
-
-    return 1;
-}
-
 int parse_to_auth_req(struct blob_attr *msg, auth_entry *auth_req) {
     struct blob_attr *tb[__AUTH_MAX];
 
@@ -401,7 +369,7 @@ bool discard_entry = true;
     if (auth_req == NULL)
     {
         dawnlog_error("Memory allocation of auth req failed!");
-        return -1;
+        return ret; // Allow if we can't evalute a reason to deny
     }
 
     parse_to_auth_req(msg, auth_req);
@@ -409,15 +377,55 @@ bool discard_entry = true;
     dawnlog_debug("Auth entry: ");
     print_auth_entry(DAWNLOG_DEBUG, auth_req);
 
-    if (!mac_in_maclist(auth_req->client_addr)) {
+    if (dawn_metric.eval_auth_req <= 0) {
+        dawnlog_trace("Allow authentication due to not evaluating requests");
+    }
+    else if (mac_in_maclist(auth_req->client_addr)) {
+        dawnlog_trace("Allow authentication due to mac_in_maclist()");
+    }
+    else {
         pthread_mutex_lock(&probe_array_mutex);
+
+        if (dawnlog_showing(DAWNLOG_DEBUG))
+            print_probe_array();
 
         probe_entry *tmp = probe_array_get_entry(auth_req->bssid_addr, auth_req->client_addr);
 
         pthread_mutex_unlock(&probe_array_mutex);
 
+        /*** Deprecated function decide_function() removed here ***/
+        int deny_request = 0;
+        
         // block if entry was not already found in probe database
-        if (tmp == NULL || !decide_function(tmp, REQ_TYPE_AUTH)) {
+        if (tmp == NULL) {
+            dawnlog_trace("Deny authentication due to no probe entry");
+            deny_request = 1;
+        }
+#if 0
+        // Already know this is false from outer test above
+        else if (mac_in_maclist(probe_req_updated->client_addr)) {
+            dawnlog_trace("Short cut due to mac_in_maclist()");
+        }
+#endif
+        else if (tmp->counter < dawn_metric.min_probe_count) {
+            dawnlog_trace("Deny authentication due to low probe count");
+            deny_request = 1;
+        }
+        else
+        {
+            // find own probe entry and calculate score
+            ap* this_ap = ap_array_get_ap(tmp->bssid_addr, tmp->ssid);
+            if (this_ap != NULL && better_ap_available(this_ap, tmp->client_addr, NULL) > 0) {
+                dawnlog_trace("Deny authentication due to better AP available");
+                deny_request = 1;
+            }
+            else
+                // maybe send here that the client is connected?
+                dawnlog_trace("Allow authentication!\n");
+        }
+        /*** End of decide_function() rework ***/
+
+        if (deny_request) {
             if (dawn_metric.use_driver_recog) {
                 if (auth_req == insert_to_denied_req_array(auth_req, 1, time(0)))
                     discard_entry = false;
@@ -440,29 +448,73 @@ int ret = WLAN_STATUS_SUCCESS;
 int discard_entry = true;
 
     dawnlog_debug_func("Entering...");
-    print_probe_array();
+
     auth_entry* assoc_req = dawn_malloc(sizeof(struct auth_entry_s));
     if (assoc_req == NULL)
-        return -1;
+    {
+        dawnlog_error("Memory allocation of assoc req failed!");
+        return ret; // Allow if we can't evalute a reason to deny
+    }
 
     parse_to_assoc_req(msg, assoc_req);
     dawnlog_debug("Association entry: ");
     print_auth_entry(DAWNLOG_DEBUG, assoc_req);
 
-    if (!mac_in_maclist(assoc_req->client_addr)) {
+    if (dawn_metric.eval_assoc_req <= 0) {
+        dawnlog_trace("Allow association due to not evaluating requests");
+    }
+    else if (mac_in_maclist(assoc_req->client_addr)) {
+        dawnlog_trace("Allow association due to mac_in_maclist()");
+    } else {
         pthread_mutex_lock(&probe_array_mutex);
+
+        if (dawnlog_showing(DAWNLOG_DEBUG))
+            print_probe_array();
 
         probe_entry *tmp = probe_array_get_entry(assoc_req->bssid_addr, assoc_req->client_addr);
 
         pthread_mutex_unlock(&probe_array_mutex);
 
+        /*** Deprecated function decide_function() removed here ***/
+        int deny_request = 0;
+        
         // block if entry was not already found in probe database
-        if (tmp == NULL || !decide_function(tmp, REQ_TYPE_ASSOC)) {
+        if (tmp == NULL) {
+            dawnlog_trace("Deny association due to no probe entry found");
+            deny_request = 1;
+        }
+#if 0
+        // Already know this is false from outer test above
+        else if (mac_in_maclist(tmp->client_addr)) {
+            dawnlog_trace("Allow due to mac_in_maclist()");
+        }
+#endif
+        else if (tmp->counter < dawn_metric.min_probe_count) {
+            dawnlog_trace("Deny association due to low probe count");
+            deny_request = 1;
+        }
+        else
+        {
+            // find own probe entry and calculate score
+            ap* this_ap = ap_array_get_ap(tmp->bssid_addr, tmp->ssid);
+            if (this_ap != NULL && better_ap_available(this_ap, tmp->client_addr, NULL) > 0) {
+                dawnlog_trace("Deny association due to better AP available");
+                deny_request = 1;
+            }
+            else
+                dawnlog_trace("Allow association!\n");
+        }
+        /*** End of decide_function() rework ***/
+
+        if (deny_request) {
+            if (tmp != NULL)
+                print_probe_entry(DAWNLOG_DEBUG, tmp);
+
             if (dawn_metric.use_driver_recog) {
                 if (assoc_req == insert_to_denied_req_array(assoc_req, 1, time(0)))
                     discard_entry = false;
             }
-            return dawn_metric.deny_assoc_reason;
+            ret = dawn_metric.deny_assoc_reason;
         }
     }
 
@@ -475,14 +527,21 @@ int discard_entry = true;
     return ret;
 }
 
-static int handle_probe_req(struct blob_attr *msg) {
+static int handle_probe_req(struct blob_attr* msg) {
     // MUSTDO: Untangle dawn_malloc() and linking of probe_entry
     probe_entry* probe_req = parse_to_probe_req(msg);
-    probe_entry* probe_req_updated = NULL;
+
     dawnlog_debug_func("Entering...");
 
-    if (probe_req != NULL) {
-        probe_req_updated = insert_to_array(probe_req, true, true, false, time(0));
+
+    if (probe_req == NULL)
+    {
+        dawnlog_error("Parse of probe req failed!");
+        return WLAN_STATUS_SUCCESS; // Allow if we can't evalute a reason to deny
+    }
+    else
+    {
+        probe_entry* probe_req_updated = insert_to_array(probe_req, true, true, false, time(0));
         // If insert finds an existing entry, rather than linking in our new one,
         // send new probe req because we want to stay synced.
         // If not, probe_req and probe_req_updated should be equivalent
@@ -494,7 +553,35 @@ static int handle_probe_req(struct blob_attr *msg) {
 
         ubus_send_probe_via_network(probe_req_updated);
 
-        if (!decide_function(probe_req_updated, REQ_TYPE_PROBE)) {
+        /*** Deprecated function decide_function() removed here ***/
+        int deny_request = 0;
+
+        if (dawn_metric.eval_probe_req <= 0) {
+            dawnlog_trace("Allow probe due to not evaluating requests");
+        }
+        else if (mac_in_maclist(probe_req_updated->client_addr)) {
+            dawnlog_trace("Allow probe due to mac_in_maclist()");
+        }
+        else if (probe_req_updated->counter < dawn_metric.min_probe_count) {
+            dawnlog_trace("Deny probe due to low probe count");
+            deny_request = 1;
+        }
+        else
+        {
+            // find own probe entry and calculate score
+            ap* this_ap = ap_array_get_ap(probe_req_updated->bssid_addr, probe_req_updated->ssid);
+            if (this_ap != NULL && better_ap_available(this_ap, probe_req_updated->client_addr, NULL) > 0) {
+                dawnlog_trace("Deny probe due to better AP available");
+                deny_request = 1;
+            }
+            else
+            {
+                dawnlog_trace("Allow probe request!");
+            }
+        }
+        /*** End of decide_function() rework ***/
+
+        if (deny_request) {
             return WLAN_STATUS_AP_UNABLE_TO_HANDLE_NEW_STA; // no reason needed...
         }
     }

--- a/src/utils/ubus.c
+++ b/src/utils/ubus.c
@@ -441,25 +441,25 @@ int discard_entry = true;
 
     dawnlog_debug_func("Entering...");
     print_probe_array();
-    auth_entry* auth_req = dawn_malloc(sizeof(struct auth_entry_s));
-    if (auth_req == NULL)
+    auth_entry* assoc_req = dawn_malloc(sizeof(struct auth_entry_s));
+    if (assoc_req == NULL)
         return -1;
 
-    parse_to_assoc_req(msg, auth_req);
+    parse_to_assoc_req(msg, assoc_req);
     dawnlog_debug("Association entry: ");
-    print_auth_entry(DAWNLOG_DEBUG, auth_req);
+    print_auth_entry(DAWNLOG_DEBUG, assoc_req);
 
-    if (!mac_in_maclist(auth_req->client_addr)) {
+    if (!mac_in_maclist(assoc_req->client_addr)) {
         pthread_mutex_lock(&probe_array_mutex);
 
-        probe_entry *tmp = probe_array_get_entry(auth_req->bssid_addr, auth_req->client_addr);
+        probe_entry *tmp = probe_array_get_entry(assoc_req->bssid_addr, assoc_req->client_addr);
 
         pthread_mutex_unlock(&probe_array_mutex);
 
         // block if entry was not already found in probe database
         if (tmp == NULL || !decide_function(tmp, REQ_TYPE_ASSOC)) {
             if (dawn_metric.use_driver_recog) {
-                if (auth_req == insert_to_denied_req_array(auth_req, 1, time(0)))
+                if (assoc_req == insert_to_denied_req_array(assoc_req, 1, time(0)))
                     discard_entry = false;
             }
             return dawn_metric.deny_assoc_reason;
@@ -468,8 +468,8 @@ int discard_entry = true;
 
     if (discard_entry)
     {
-        dawn_free(auth_req);
-        auth_req = NULL;
+        dawn_free(assoc_req);
+        assoc_req = NULL;
     }
 
     return ret;
@@ -503,8 +503,10 @@ static int handle_probe_req(struct blob_attr *msg) {
     return WLAN_STATUS_SUCCESS;
 }
 
+// FIXME: Seems to do nothing...
 static int handle_beacon_rep(struct blob_attr *msg) {
     dawnlog_debug_func("Entering...");
+
     if (parse_to_beacon_rep(msg) == 0) {
         // dawnlog_debug("Inserting beacon Report!\n");
         // insert_to_array(beacon_rep, 1);
@@ -936,7 +938,7 @@ void update_tcp_connections(struct uloop_timeout *t) {
     if (strcmp(network_config.server_ip, ""))
     {
         // nothing happens if tcp connection is already established
-        add_tcp_conncection(network_config.server_ip, network_config.tcp_port);
+        add_tcp_connection(network_config.server_ip, network_config.tcp_port);
     }
     if (network_config.network_option == 2) // mdns enabled?
     {
@@ -1093,7 +1095,7 @@ static void ubus_umdns_cb(struct ubus_request *req, int type, struct blob_attr *
         } else {
             return;
         }
-        add_tcp_conncection(blobmsg_get_string(tb_dawn[DAWN_UMDNS_IPV4]), blobmsg_get_u32(tb_dawn[DAWN_UMDNS_PORT]));
+        add_tcp_connection(blobmsg_get_string(tb_dawn[DAWN_UMDNS_IPV4]), blobmsg_get_u32(tb_dawn[DAWN_UMDNS_PORT]));
     }
 }
 

--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -1,5 +1,10 @@
 #include <string.h>
 #include <ctype.h>
+#include <errno.h>
+
+#include <stdarg.h>
+#include <syslog.h>
+#include <stdio.h>
 
 #include "utils.h"
 
@@ -19,4 +24,107 @@ int string_is_greater(char *str, char *str_2) {
         }
     }
     return length_1 > length_2;
+}
+
+// Size implied by https://man7.org/linux/man-pages/man3/strerror.3.html
+char dawnlog_pbuf[1024] = "NOT SET";
+
+static int _logdest = DAWNLOG_DEST_SYSLOG; // Assume daemon, logging to syslog
+static int _logmin = DAWNLOG_ALWAYS;      // Anything of lower priority is suppressed
+
+void dawnlog_dest(int logdest)
+{
+    _logdest = logdest;
+}
+
+void dawnlog_minlevel(int level)
+{
+    // Don't allow certain prioriites to be suppressed
+    if (level < DAWNLOG_ALWAYS)
+    {
+        _logmin = level;
+    }
+}
+
+int dawnlog_showing(int level)
+{
+    return(level >= _logmin);
+}
+
+void dawnlog(int level, const char* fmt, ...)
+{
+
+    if ((level & DAWNLOG_PRIMASK) >= _logmin)
+    {
+        // Attempt to replicate what perror() does...
+        // dawnlog_buf is already referenced by macro expanded format string, so set it to a value
+        if ((level & DAWNLOG_PERROR) == DAWNLOG_PERROR)
+        {
+            strerror_r(errno, dawnlog_pbuf, 1024);
+        }
+
+        va_list ap;
+        va_start(ap, fmt);
+
+        int sl = LOG_NOTICE;  // Should always be mapped to a different value
+        char *iotag = "default: ";
+
+        switch (level)
+        {
+        case DAWNLOG_ERROR:
+            sl = LOG_ERR;
+            iotag = "error: ";
+            break;
+        case DAWNLOG_WARNING:
+            sl = LOG_WARNING;
+            iotag = "warning: ";
+            break;
+        case DAWNLOG_ALWAYS:
+            sl = LOG_INFO;
+            iotag = "info: ";
+            break;
+        case DAWNLOG_INFO:
+            sl = LOG_INFO;
+            iotag = "info: ";
+            break;
+        case DAWNLOG_TRACE:
+            sl = LOG_DEBUG;
+            iotag = "trace: ";
+            break;
+        case DAWNLOG_DEBUG:
+            sl = LOG_DEBUG;
+            iotag = "debug: ";
+            break;
+        }
+
+        if (_logdest == DAWNLOG_DEST_SYSLOG)
+        {
+            vsyslog(sl, fmt, ap);
+        }
+        else
+        {
+            int l = strlen(fmt);
+            if (l)
+            {
+                FILE* f = (level == DAWNLOG_ERROR || level == DAWNLOG_WARNING) ? stderr : stdout;
+
+                fprintf(f, "%s", iotag);
+                vfprintf(f, fmt, ap);
+
+                // Messages created for syslog() may not have a closing newline, so add one if using stdio
+                if (fmt[l - 1] != '\n')
+                    fprintf(f, "\n");
+            }
+        }
+
+        va_end(ap);
+    }
+}
+
+/* Return pointer to filename part of full path */
+const char* dawnlog_basename(const char* file)
+{
+    char* xfile = strrchr(file, '/');
+
+    return(xfile ? xfile + 1 : file);
 }


### PR DESCRIPTION
Replaces:
https://github.com/berlin-open-wireless-lab/DAWN/pull/157

```
LOGGING: Provide multi-priority syslog() based logging to improve user and developer experience
Add dawnlog_* functions and macros to convert printf() family and perror() logging to syslog() family
Removed unnecessary sprintf() for building log strings (embed format directly)
Add local config settings for log level
Add command line parameters for log level and destination
Set default log level to suppress a lot of previously noisy messages
Restore some previously removed noisy messages as DEBUG level in case they help in future
Eliminate DAWN_NO_OUTPUT static code checks which are no longer used

MEM: TIghten up some memory handling to help spot errors
Set pointers to NULL after free() to help force out memory handling errors
Add some extra memory / resource tracking to try and chase out latent bugs / leaks
Fixed a couple of memory traces that were misreporting

MAINT: General revisions to maintain code (no functional changes intended)
Removed unnecessary linked-list length checks
Fixed some typos on function names / comments
Changed how test_storage forces SEGV due to new compiler warnings

FIX1: Bug that could proably cause ineffciency or confusion in multi-SSID environments
Adjusted erroneus match test in ap_array_insert()

FIX2: Bug that was preventing kicking working due to mishandling of bandwidth discovery
Fixed bug in use of get_bandwidth_iwinfo() in AP kicking
Fix rounding of transmission rate calculations in get_bandwidth_iwinfo()
Restructure of get_bandwidth...() while finding bug

FEAT1: Refresh of kicking algorithm to minimise messages and streamline some code
Removed decide_function() which made some logic hard to follow
Removed kick_client() function to streamline code
Revised kicking algorithm code to give better user messages
```