### PR TITLE
ubus: add missing lock for ubus hearing_map

### DIFF
--- a/src/utils/ubus.c
+++ b/src/utils/ubus.c
@@ -2000,8 +2000,9 @@ int build_hearing_map_sort_client(struct blob_buf *b) {
         }
 
         // Find the client if it is actually connected somewhere...
-        dawn_mutex_require(&client_array_mutex);
+        dawn_mutex_lock(&client_array_mutex);
         client* this_client = client_array_get_client(this_entry->k->client_addr);
+        dawn_mutex_unlock(&client_array_mutex);
 
         // Add the probe details
         char ap_mac_buf[20];


### PR DESCRIPTION
In the build_hearing_map_sort_client there was a dawn_mutex_require
without having locked the mutex resulting in warnings:

  daemon.warn dawn: MUTEX require = 4226B8@ubus.c:2003[2012069248l] - appears to be UNLOCKED!
  daemon.warn dawn: MUTEX require = 4226B8@datastorage.c:694[2012069248l] - appears to be UNLOCKED!

I guess it was a typo, because before entering the
client_array_get_client function the mutex client_array_mutex needs to
be locked and not required.
