### PR TITLE
ubus.c: only add nr entries matching our own SSID

### DIFF
--- a/src/utils/ubus.c
+++ b/src/utils/ubus.c
@@ -2236,7 +2236,7 @@ int ap_get_nr(struct blob_buf* b_local, struct dawn_mac own_bssid_addr, const ch
         for (struct mac_entry_s* n = preferred_list; n; n = n->next_mac) {
             dawn_mutex_require(&ap_array_mutex);
             ap* j = ap_array_get_ap(n->mac);
-            if (j)
+            if (j && !strncmp((char*)j->ssid, ssid, SSID_MAX_LEN))
                 blobmsg_add_nr(b_local, j);
         }
 


### PR DESCRIPTION
The preferred neighbors list may have BSSIDs with different SSIDs.  Add
only those that match the interface's SSID.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---
6bf3cd77 removed the SSID check from `ap_array_get_ap()`, but did not add the check in `ap_get_nr()`.

Here are the relevant parts of my config:
**/etc/config/wireless**
```
config wifi-iface 'Cote_radio1'
        option device 'radio1'
        option ifname 'wlan5g'
        option network 'lan'
        option mode 'ap'
        option ssid 'Cote'

config wifi-iface 'Cote2_radio1'
        option device 'radio1'
        option ifname 'wcote2'
        option network 'lan'
        option mode 'ap'
        option ssid 'Cote2'
```

**/etc/config/dawn**
```
config metric '802_11a'
        list neighbors 'XX:XX:XX:XX:XX:F6'
        list neighbors 'XX:XX:XX:XX:XX:CC'
        list neighbors 'XX:XX:XX:XX:XX:CA'
        list neighbors 'XX:XX:XX:XX:XX:D0'
        list neighbors 'XX:XX:XX:XX:XX:D2'
        list neighbors 'XX:XX:XX:XX:XX:4A'
        list neighbors 'XX:XX:XX:XX:XX:25'
        list neighbors 'XX:XX:XX:XX:XX:F5'
```
There are two SSIDs: Cote, Cote2.  The neighbors list only contains entries for Cote, because it has more than 6 neighbors, while Cote2 has only 5.

Here's the current behavior.  Notice that there are multiple ssids here--Cote(`436f7465`), Cote2(`436f7465`**`32`**):
```
# hostapd_cli -i wcote2 show_neighbor | sed -e 's/^\(..\):..:..:..:../\1:xx:xx:xx:xx/' -e 's/nr=\(..\)......../nr=\1xxxxxxxx/'
e8:xx:xx:xx:xx:f6 ssid=436f7465 nr=e8xxxxxxxxf6ff5900008064090603026a00
e8:xx:xx:xx:xx:cc ssid=436f7465 nr=e8xxxxxxxxccff5900008034090603023a00
e8:xx:xx:xx:xx:ca ssid=436f7465 nr=e8xxxxxxxxcaef5900008024090603022a00
e8:xx:xx:xx:xx:d0 ssid=436f7465 nr=e8xxxxxxxxd0ff5900008084090603028a00
e8:xx:xx:xx:xx:d2 ssid=436f7465 nr=e8xxxxxxxxd2ef5900008099090603029b00
e8:xx:xx:xx:xx:25 ssid=436f7465 nr=e8xxxxxxxx25ef090000510d070603000d00
e8:xx:xx:xx:xx:f5 ssid=436f7465 nr=e8xxxxxxxxf5ef0900005105070603000500
ea:xx:xx:xx:xx:ca ssid=436f746532 nr=eaxxxxxxxxcaef5900008024090603022a00
ea:xx:xx:xx:xx:d2 ssid=436f746532 nr=eaxxxxxxxxd2ef5900008099090603029b00
ea:xx:xx:xx:xx:f6 ssid=436f746532 nr=eaxxxxxxxxf6ff5900008064090603026a00
ea:xx:xx:xx:xx:cc ssid=436f746532 nr=eaxxxxxxxxccff5900008034090603023a00
ea:xx:xx:xx:xx:d0 ssid=436f746532 nr=eaxxxxxxxxd0ff5900008084090603028a00
ea:xx:xx:xx:xx:26 ssid=436f746532 nr=eaxxxxxxxx26ff5900008074090603027a00
```

The correct behavior would be to have only the Cote2 entries:
```
# hostapd_cli -i wcote2 show_neighbor | sed -e 's/^\(..\):..:..:..:../\1:xx:xx:xx:xx/' -e 's/nr=\(..\)......../nr=\1xxxxxxxx/'
ea:xx:xx:xx:xx:ca ssid=436f746532 nr=eaxxxxxxxxcaef5900008024090603022a00
ea:xx:xx:xx:xx:d2 ssid=436f746532 nr=eaxxxxxxxxd2ef5900008099090603029b00
ea:xx:xx:xx:xx:f6 ssid=436f746532 nr=eaxxxxxxxxf6ff5900008064090603026a00
ea:xx:xx:xx:xx:cc ssid=436f746532 nr=eaxxxxxxxxccff5900008034090603023a00
ea:xx:xx:xx:xx:d0 ssid=436f746532 nr=eaxxxxxxxxd0ff5900008084090603028a00
ea:xx:xx:xx:xx:26 ssid=436f746532 nr=eaxxxxxxxx26ff5900008074090603027a00
```

This was tested on Linksys E8450 running OpenWRT master [openwrt/openwrt:ba7da73680](https://github.com/openwrt/openwrt/commit/ba7da7368086d0721da7cd4d627209dffda5c1d6).