### PR TITLE
network: ping pong keepalive for tcp connections

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -263,7 +263,7 @@ grep 'CONFIG-T:' `find . -type f -name "*.[ch]"`|sed 's/^.*CONFIG-.: *\(.*\)$/|\
 -->
 |Parameter|Purpose|Notes [Default is bracketed]|
 |---------|-------|-----|
-|client_timeout|Timespan until a client is seen as disconnected|[60]|
+|con_timeout|Timespan until a connection is seen as disconnected|[60]|
 |remove_ap|Timer to remove expired AP entries from core data set|[460]|
 |remove_client|Timer to remove expired client entries from core data set|[15]|
 |remove_probe|Timer to remove expired PROBE and BEACON entries from core data set|[30]|

--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -263,6 +263,7 @@ grep 'CONFIG-T:' `find . -type f -name "*.[ch]"`|sed 's/^.*CONFIG-.: *\(.*\)$/|\
 -->
 |Parameter|Purpose|Notes [Default is bracketed]|
 |---------|-------|-----|
+|client_timeout|Timespan until a client is seen as disconnected|[60]|
 |remove_ap|Timer to remove expired AP entries from core data set|[460]|
 |remove_client|Timer to remove expired client entries from core data set|[15]|
 |remove_probe|Timer to remove expired PROBE and BEACON entries from core data set|[30]|

--- a/dawn-config
+++ b/dawn-config
@@ -17,7 +17,7 @@ config hostapd
 	option hostapd_dir '/var/run/hostapd'
 
 config times
-	option client_timeout '60'
+	option con_timeout '60'
 	option update_client '10'
 	option remove_client '15'
 	option remove_probe '30'

--- a/dawn-config
+++ b/dawn-config
@@ -17,6 +17,7 @@ config hostapd
 	option hostapd_dir '/var/run/hostapd'
 
 config times
+	option client_timeout '60'
 	option update_client '10'
 	option remove_client '15'
 	option remove_probe '30'

--- a/src/include/datastorage.h
+++ b/src/include/datastorage.h
@@ -109,6 +109,7 @@ struct time_config_s {
     time_t update_tcp_con; // Refresh network connections
     time_t update_chan_util; // Refresh per radio / SSID channel util info
     time_t update_beacon_reports; // Request BEACON from capable clients
+    time_t client_timeout; // Check for client timeouts.
 };
 
 struct local_config_s {

--- a/src/include/datastorage.h
+++ b/src/include/datastorage.h
@@ -109,7 +109,7 @@ struct time_config_s {
     time_t update_tcp_con; // Refresh network connections
     time_t update_chan_util; // Refresh per radio / SSID channel util info
     time_t update_beacon_reports; // Request BEACON from capable clients
-    time_t client_timeout; // Check for client timeouts.
+    time_t con_timeout; // Check for connection timeouts.
 };
 
 struct local_config_s {

--- a/src/include/tcpsocket.h
+++ b/src/include/tcpsocket.h
@@ -5,7 +5,7 @@
 #include <netinet/in.h>
 
 #define ARRAY_NETWORK_LEN 50
-#define CHECK_CLIENT_TIMEOUT 5
+#define CHECK_TIMEOUT 10
 
 struct network_con_s {
     struct list_head list;
@@ -14,6 +14,7 @@ struct network_con_s {
     struct ustream_fd stream;
     struct sockaddr_in sock_addr;
     int connected;
+    time_t time_alive;
 };
 
 /**
@@ -38,9 +39,14 @@ int run_server(int port);
 void send_tcp(char *msg);
 
 /**
- * Check sockets for client timeouts.
+ * Send ping to clients
  */
-void check_client_timeout(int timeout);
+void server_to_clients_ping(void);
+
+/**
+ * Check sockets timeouts.
+ */
+void check_timeout(int timeout);
 
 /**
  * Debug message.

--- a/src/include/tcpsocket.h
+++ b/src/include/tcpsocket.h
@@ -5,6 +5,7 @@
 #include <netinet/in.h>
 
 #define ARRAY_NETWORK_LEN 50
+#define CHECK_CLIENT_TIMEOUT 5
 
 struct network_con_s {
     struct list_head list;
@@ -35,6 +36,11 @@ int run_server(int port);
  * @param msg
  */
 void send_tcp(char *msg);
+
+/**
+ * Check sockets for client timeouts.
+ */
+void check_client_timeout(int timeout);
 
 /**
  * Debug message.

--- a/src/utils/dawn_uci.c
+++ b/src/utils/dawn_uci.c
@@ -79,7 +79,7 @@ struct time_config_s uci_get_time_config() {
         .update_tcp_con = 10,
         .update_chan_util = 5,
         .update_beacon_reports = 20,
-        .client_timeout = 60,
+        .con_timeout = 60,
     };
 
     dawnlog_debug_func("Entering...");
@@ -106,8 +106,8 @@ struct time_config_s uci_get_time_config() {
             DAWN_SET_CONFIG_TIME(ret, s, update_chan_util);
             //CONFIG-T: update_beacon_reports|Timer to ask all connected clients for a new BEACON REPORT|[20]
             DAWN_SET_CONFIG_TIME(ret, s, update_beacon_reports);
-            //CONFIG-T: client_timeout|Timespan to check if a client timed out|[60]
-            DAWN_SET_CONFIG_TIME(ret, s, client_timeout);
+            //CONFIG-T: con_timeout|Timespan to check if a connection timed out|[60]
+            DAWN_SET_CONFIG_TIME(ret, s, con_timeout);
             return ret;
         }
     }

--- a/src/utils/dawn_uci.c
+++ b/src/utils/dawn_uci.c
@@ -79,6 +79,7 @@ struct time_config_s uci_get_time_config() {
         .update_tcp_con = 10,
         .update_chan_util = 5,
         .update_beacon_reports = 20,
+        .client_timeout = 60,
     };
 
     dawnlog_debug_func("Entering...");
@@ -105,6 +106,8 @@ struct time_config_s uci_get_time_config() {
             DAWN_SET_CONFIG_TIME(ret, s, update_chan_util);
             //CONFIG-T: update_beacon_reports|Timer to ask all connected clients for a new BEACON REPORT|[20]
             DAWN_SET_CONFIG_TIME(ret, s, update_beacon_reports);
+            //CONFIG-T: client_timeout|Timespan to check if a client timed out|[60]
+            DAWN_SET_CONFIG_TIME(ret, s, client_timeout);
             return ret;
         }
     }

--- a/src/utils/msghandler.c
+++ b/src/utils/msghandler.c
@@ -656,6 +656,7 @@ enum {
     UCI_UPDATE_TCP_CON,
     UCI_UPDATE_CHAN_UTIL,
     UCI_UPDATE_BEACON_REPORTS,
+    UCI_CLIENT_TIMEOUT,
     __UCI_TIMES_MAX,
 };
 
@@ -713,6 +714,7 @@ static const struct blobmsg_policy uci_times_policy[__UCI_TIMES_MAX] = {
         [UCI_UPDATE_TCP_CON] = {.name = "update_tcp_con", .type = BLOBMSG_TYPE_INT32},
         [UCI_UPDATE_CHAN_UTIL] = {.name = "update_chan_util", .type = BLOBMSG_TYPE_INT32},
         [UCI_UPDATE_BEACON_REPORTS] = {.name = "update_beacon_reports", .type = BLOBMSG_TYPE_INT32},
+        [UCI_CLIENT_TIMEOUT] = {.name = "client_timeout", .type = BLOBMSG_TYPE_INT32},
 };
 
 static void set_uci_item(char* m, struct blob_attr* a)
@@ -894,6 +896,8 @@ static int handle_uci_config(struct blob_attr* msg) {
     set_uci_item("dawn.@times[0].update_chan_util=%d", tb_times[UCI_UPDATE_CHAN_UTIL]);
 
     set_uci_item("dawn.@times[0].update_beacon_reports=%d", tb_times[UCI_UPDATE_BEACON_REPORTS]);
+
+    set_uci_item("dawn.@times[0].client_timeout=%d", tb_times[UCI_CLIENT_TIMEOUT]);
 
     uci_reset();
     dawn_metric = uci_get_dawn_metric();

--- a/src/utils/msghandler.c
+++ b/src/utils/msghandler.c
@@ -656,7 +656,7 @@ enum {
     UCI_UPDATE_TCP_CON,
     UCI_UPDATE_CHAN_UTIL,
     UCI_UPDATE_BEACON_REPORTS,
-    UCI_CLIENT_TIMEOUT,
+    UCI_CON_TIMEOUT,
     __UCI_TIMES_MAX,
 };
 
@@ -714,7 +714,7 @@ static const struct blobmsg_policy uci_times_policy[__UCI_TIMES_MAX] = {
         [UCI_UPDATE_TCP_CON] = {.name = "update_tcp_con", .type = BLOBMSG_TYPE_INT32},
         [UCI_UPDATE_CHAN_UTIL] = {.name = "update_chan_util", .type = BLOBMSG_TYPE_INT32},
         [UCI_UPDATE_BEACON_REPORTS] = {.name = "update_beacon_reports", .type = BLOBMSG_TYPE_INT32},
-        [UCI_CLIENT_TIMEOUT] = {.name = "client_timeout", .type = BLOBMSG_TYPE_INT32},
+        [UCI_CON_TIMEOUT] = {.name = "con_timeout", .type = BLOBMSG_TYPE_INT32},
 };
 
 static void set_uci_item(char* m, struct blob_attr* a)
@@ -897,7 +897,7 @@ static int handle_uci_config(struct blob_attr* msg) {
 
     set_uci_item("dawn.@times[0].update_beacon_reports=%d", tb_times[UCI_UPDATE_BEACON_REPORTS]);
 
-    set_uci_item("dawn.@times[0].client_timeout=%d", tb_times[UCI_CLIENT_TIMEOUT]);
+    set_uci_item("dawn.@times[0].con_timeout=%d", tb_times[UCI_CON_TIMEOUT]);
 
     uci_reset();
     dawn_metric = uci_get_dawn_metric();

--- a/src/utils/ubus.c
+++ b/src/utils/ubus.c
@@ -23,6 +23,8 @@ void update_clients(struct uloop_timeout *t);
 
 void update_tcp_connections(struct uloop_timeout *t);
 
+void check_client_timeouts(struct uloop_timeout *t);
+
 void update_channel_utilization(struct uloop_timeout *t);
 
 void run_server_update(struct uloop_timeout *t);
@@ -37,6 +39,9 @@ struct uloop_timeout hostapd_timer = {
 };
 struct uloop_timeout tcp_con_timer = {
         .cb = update_tcp_connections
+};
+struct uloop_timeout client_timeout_timer = {
+        .cb = check_client_timeouts
 };
 struct uloop_timeout channel_utilization_timer = {
         .cb = update_channel_utilization
@@ -1148,11 +1153,20 @@ void update_tcp_connections(struct uloop_timeout *t) {
     uloop_timeout_set(&tcp_con_timer, timeout_config.update_tcp_con * 1000);
 }
 
+void check_client_timeouts(struct uloop_timeout *t) {
+    dawnlog_debug_func("Entering...");
+
+    check_client_timeout(timeout_config.client_timeout);
+
+    uloop_timeout_set(&client_timeout_timer, CHECK_CLIENT_TIMEOUT * 1000);
+}
+
 void start_tcp_con_update() {
     dawnlog_debug_func("Entering...");
 
     // update connections
     uloop_timeout_add(&tcp_con_timer); // callback = update_tcp_connections
+    uloop_timeout_add(&client_timeout_timer); // callback = client_timeout
 }
 
 void update_hostapd_sockets(struct uloop_timeout *t) {
@@ -1888,6 +1902,7 @@ int uci_send_via_network()
     blobmsg_add_u32(&b, "update_tcp_con", timeout_config.update_tcp_con);
     blobmsg_add_u32(&b, "update_chan_util", timeout_config.update_chan_util);
     blobmsg_add_u32(&b, "update_beacon_reports", timeout_config.update_beacon_reports);
+    blobmsg_add_u32(&b, "client_timeout", timeout_config.client_timeout);
     blobmsg_close_table(&b, times);
 
     send_blob_attr_via_network(b.head, "uci");


### PR DESCRIPTION
To make the tcp connections keepalive and better handle the timeout of connections

`con_timeout` indicate the connection timeout and it is configurable

this change is rebase on https://github.com/berlin-open-wireless-lab/DAWN/pull/185

what client do:
make client-to-server connection, receive ping msg and send pong ack, timer check that if it take more than 60s receive no ping msg, then trigger the timeout action and close the client-to-server connection.

what server do:
accept new connection, timer to send ping to client, accept pong ack msg, timer check that if it do not receive pong ack for a long time (maybe 60s), then assume that the client is dead, close the connection.
