### PR TITLE
datastorage: fix ap_array_unlink_entry always returns NULL

### DIFF
--- a/src/storage/datastorage.c
+++ b/src/storage/datastorage.c
@@ -1004,7 +1004,6 @@ static __inline__ ap* ap_array_unlink_entry(ap** i)
 {
     ap* entry = *i;
     *i = entry->next_ap;
-    entry = NULL;
     ap_entry_last--;
 
     return entry;


### PR DESCRIPTION
For an unknown reason the entry that is returned in ap_array_unlink_entry
was always set to NULL. This commit changes the function so it returns the
ap that should be unlinked. This is needed to free the corresponding
memory that is allocated by the ap struct.

Thanks a lot to ptpt52 for reporting this issue.
