### PR TITLE
datastorage: fix use-after-free compiler error

### DIFF
--- a/src/storage/datastorage.c
+++ b/src/storage/datastorage.c
@@ -1332,8 +1332,8 @@ void insert_macs_from_file() {
         }
     }
 
-    fclose(fp);
     dawn_unregmem(fp);
+    fclose(fp);
     if (line)
     {
         free(line);


### PR DESCRIPTION
I  am not familiar with how are  `dawn_regmem()` and `dawn_unregmem()` supposed to be used,  so I might be wrong.

Nevertheless, it seems odd to use `FILE  *  fp`  pointer after `fclose()`, regardless how it is supposed to be handled in `dawn_unregmem()`.

This should fix the "use-after-free" compiler error.

Closes: #198