### PR TITLE
network: IP_MULTICAST_LOOP should be set to false/0

### DIFF
--- a/src/network/multicastsocket.c
+++ b/src/network/multicastsocket.c
@@ -45,7 +45,7 @@ int setup_multicast_socket(const char *_multicast_ip, unsigned short _multicast_
     }
 
     // allow broadcast
-    loop = 1;
+    loop = 0;
     if (setsockopt(sock,
                    IPPROTO_IP,
                    IP_MULTICAST_LOOP,


### PR DESCRIPTION
If `IP_MULTICAST_LOOP` is left to `true`/`1` the dawn instance will send the packet out and then receive it itself, this will generate a '_Remote PROBE updated client / BSSID = XX:XX:XX:XX:XX:XX / YY:YY:YY:YY:YY:YY_' **after every** '_Local PROBE used to update client / BSSID = XX:XX:XX:XX:XX:XX / YY:YY:YY:YY:YY:YY_'