### PR TITLE
Do not kick clients depending on bandwidth when bandwidth_threshold is set to 0

### DIFF
--- a/src/storage/datastorage.c
+++ b/src/storage/datastorage.c
@@ -562,15 +562,17 @@ int kick_clients(struct dawn_mac bssid_mac, uint32_t id) {
                 }
                 else
                 {
+		  if (dawn_metric.bandwidth_threshold != 0)
+		  {
                     // only use rx_rate for indicating if transmission is going on
                     // <= 6MBits <- probably no transmission
                     // tx_rate has always some weird value so don't use ist
-                    if (have_bandwidth_iwinfo && dawn_metric.bandwidth_threshold != 0 && rx_rate > dawn_metric.bandwidth_threshold) {
+                    if (have_bandwidth_iwinfo && rx_rate > dawn_metric.bandwidth_threshold) {
                         dawnlog_info("Client " MACSTR ": Don't kick due to active data transfer: RX rate %f exceeds %d limit\n", MAC2STR(j->client_addr.u8), rx_rate, dawn_metric.bandwidth_threshold);
                     }
                     else
                     {
-                        if (have_bandwidth_iwinfo && dawn_metric.bandwidth_threshold != 0)
+                        if (have_bandwidth_iwinfo)
                             dawnlog_always("Client " MACSTR ": Kicking due to low active data transfer: RX rate %f below %d limit\n", MAC2STR(j->client_addr.u8), rx_rate, dawn_metric.bandwidth_threshold);
                         else
                             dawnlog_always("Client " MACSTR ": Kicking as no active transmission data for client, and / or limit of %d is OK.\n",
@@ -612,6 +614,7 @@ int kick_clients(struct dawn_mac bssid_mac, uint32_t id) {
 
                         kicked_clients++;
                     }
+		  }
                 }
             }
         }


### PR DESCRIPTION
Documentation says that you can set bandwidth_threshold to 0 to disable kicking because of low bandwidth usage. Log shows that clients are still kicked with log message `daemon.info dawn: Client ... Kicking as no active transmission data for client, and / or limit of 0 is OK`. That should not happen.