### PR TITLE
ubus: do not reiterate bss_transition_request over each SSID

### DIFF
--- a/src/utils/ubus.c
+++ b/src/utils/ubus.c
@@ -1285,13 +1285,8 @@ int bss_transition_request(uint32_t id, const struct dawn_mac client_addr, struc
     }
 
     blobmsg_close_array(&b, nbs);
-    list_for_each_entry(sub, &hostapd_sock_list, list)
-    {
-        if (sub->subscribed) {
-            int timeout = 1; //TDO: Maybe ID is wrong?! OR CHECK HERE ID
-            if(!ubus_invoke(ctx, id, "bss_transition_request", b.head, NULL, NULL, timeout * 1000)) break;
-        }
-    }
+    int timeout = 1;
+    ubus_invoke(ctx, id, "bss_transition_request", b.head, NULL, NULL, timeout * 1000);
 
     blob_buf_free(&b);
     dawn_unregmem(&b);
@@ -1325,13 +1320,8 @@ int wnm_disassoc_imminent(uint32_t id, const struct dawn_mac client_addr, struct
     }
 
     blobmsg_close_array(&b, nbs);
-    list_for_each_entry(sub, &hostapd_sock_list, list)
-    {
-        if (sub->subscribed) {
-            int timeout = 1; //TDO: Maybe ID is wrong?! OR CHECK HERE ID
-            if(!ubus_invoke(ctx, id, "bss_transition_request", b.head, NULL, NULL, timeout * 1000)) break;
-        }
-    }
+    int timeout = 1;
+    ubus_invoke(ctx, id, "bss_transition_request", b.head, NULL, NULL, timeout * 1000);
 
     blob_buf_free(&b);
     dawn_unregmem(&b);

--- a/src/utils/ubus.c
+++ b/src/utils/ubus.c
@@ -1247,14 +1247,9 @@ void del_client_interface(uint32_t id, const struct dawn_mac client_addr, uint32
     blobmsg_add_u8(&b, "deauth", deauth);
     blobmsg_add_u32(&b, "ban_time", ban_time);
 
+    int timeout = 1;
+    ubus_invoke(ctx, id, "del_client", b.head, NULL, NULL, timeout * 1000);
 
-    list_for_each_entry(sub, &hostapd_sock_list, list)
-    {
-        if (sub->subscribed) {
-            int timeout = 1;
-            ubus_invoke(ctx, id, "del_client", b.head, NULL, NULL, timeout * 1000);
-        }
-    }
     blob_buf_free(&b);
     dawn_unregmem(&b);
 }

--- a/src/utils/ubus.c
+++ b/src/utils/ubus.c
@@ -1278,8 +1278,11 @@ int bss_transition_request(uint32_t id, const struct dawn_mac client_addr, struc
     }
 
     blobmsg_close_array(&b, nbs);
-    // do not ask to leave without providing candidates, unless NR explicitly disabled or unavailable (consider empty rrm_mode)
-    if (neighbors_added || (dawn_metric.disassoc_nr_length <= 0) || (dawn_metric.set_hostapd_nr <= 0) || (timeout_config.update_beacon_reports <= 0) ) {
+    // do not ask to leave without providing candidates, unless NRs are explicitly disabled or unavailable
+    if (neighbors_added || 
+            (dawn_metric.disassoc_nr_length <= 0) || (dawn_metric.set_hostapd_nr <= 0) ||
+            // disabling 802.11k shouldn't matter unless we build dynamic NR list (consider empty rrm_mode)
+            ((timeout_config.update_beacon_reports <= 0) && (dawn_metric.set_hostapd_nr == 2)) ) {
         int timeout = 1;
         ubus_invoke(ctx, id, "bss_transition_request", b.head, NULL, NULL, timeout * 1000);
     }

--- a/src/utils/ubus.c
+++ b/src/utils/ubus.c
@@ -1280,8 +1280,11 @@ int bss_transition_request(uint32_t id, const struct dawn_mac client_addr, struc
     }
 
     blobmsg_close_array(&b, nbs);
-    int timeout = 1;
-    ubus_invoke(ctx, id, "bss_transition_request", b.head, NULL, NULL, timeout * 1000);
+    // do not ask to leave without providing candidates, unless NR explicitly disabled or unavailable (consider empty rrm_mode)
+    if (neighbors_added || (dawn_metric.disassoc_nr_length <= 0) || (dawn_metric.set_hostapd_nr <= 0) || (timeout_config.update_beacon_reports <= 0) ) {
+        int timeout = 1;
+        ubus_invoke(ctx, id, "bss_transition_request", b.head, NULL, NULL, timeout * 1000);
+    }
 
     blob_buf_free(&b);
     dawn_unregmem(&b);

--- a/src/utils/ubus.c
+++ b/src/utils/ubus.c
@@ -1289,7 +1289,7 @@ int bss_transition_request(uint32_t id, const struct dawn_mac client_addr, struc
     {
         if (sub->subscribed) {
             int timeout = 1; //TDO: Maybe ID is wrong?! OR CHECK HERE ID
-            ubus_invoke(ctx, id, "bss_transition_request", b.head, NULL, NULL, timeout * 1000);
+            if(!ubus_invoke(ctx, id, "bss_transition_request", b.head, NULL, NULL, timeout * 1000)) break;
         }
     }
 
@@ -1329,7 +1329,7 @@ int wnm_disassoc_imminent(uint32_t id, const struct dawn_mac client_addr, struct
     {
         if (sub->subscribed) {
             int timeout = 1; //TDO: Maybe ID is wrong?! OR CHECK HERE ID
-            ubus_invoke(ctx, id, "bss_transition_request", b.head, NULL, NULL, timeout * 1000);
+            if(!ubus_invoke(ctx, id, "bss_transition_request", b.head, NULL, NULL, timeout * 1000)) break;
         }
     }
 

--- a/src/utils/ubus.c
+++ b/src/utils/ubus.c
@@ -1237,7 +1237,6 @@ void del_client_all_interfaces(const struct dawn_mac client_addr, uint32_t reaso
 }
 
 void del_client_interface(uint32_t id, const struct dawn_mac client_addr, uint32_t reason, uint8_t deauth, uint32_t ban_time) {
-    struct hostapd_sock_entry *sub;
     struct blob_buf b = {0};
 
     blob_buf_init(&b, 0);
@@ -1255,7 +1254,6 @@ void del_client_interface(uint32_t id, const struct dawn_mac client_addr, uint32
 }
 
 int bss_transition_request(uint32_t id, const struct dawn_mac client_addr, struct kicking_nr* neighbor_list, uint32_t duration) {
-    struct hostapd_sock_entry* sub;
     struct blob_buf b = { 0 };
 
     dawnlog_debug_func("Entering...");
@@ -1293,7 +1291,6 @@ int bss_transition_request(uint32_t id, const struct dawn_mac client_addr, struc
 }
 
 int wnm_disassoc_imminent(uint32_t id, const struct dawn_mac client_addr, struct kicking_nr* neighbor_list, int threshold, uint32_t duration) {
-    struct hostapd_sock_entry *sub;
     struct blob_buf b = {0};
 
     dawnlog_debug_func("Entering...");


### PR DESCRIPTION
When having multiple SSIDs, bss_transition_request is sent for each one subscribed despite the fact, that ubus_invoke() is invoked using id not sub->id.

This creates redundant copies of requests and BSS-TM-RESPs polluting the air.

Consider similar sanitization in del_client_interface().