### PR TITLE
config: default duration to 150, not 0

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -154,7 +154,7 @@ grep 'CONFIG-G:' `find . -type f -name "*.[ch]"`| sed 's/^.*CONFIG-.: *\(.*\)$/|
 |deny_assoc_reason|802.11 code used when ASSOCIATION is denied|[17] (802.11 AP_UNABLE_TO_HANDLE_NEW_STA). See Note 1.|
 |deny_auth_reason|802.11 code used when AUTHENTICATION is denied|[1] (802.11 UNSPECIFIED_FAILURE). See Note 1.|
 |disassoc_nr_length|Number of entries to include in a 802.11v DISASSOCIATE Neighbor Report|[6] (Documented for use by iOS)|
-|duration|802.11k BEACON request DURATION parameter|[0]|
+|duration|802.11k BEACON request measurement duration (TUs), also used as the 802.11v BSS-TM disassociation_timer and validity_period.  Must not be 0 because some clients refuse a zero-length measurement, leaving DAWN with no BEACON REPORT data to steer on|[150]|
 |eval_assoc_req|Control whether ASSOCIATION frames are evaluated for rejection|[0 = No evaluation]; 1 = Evaluated. See Note 1.|
 |eval_auth_req|Control whether AUTHENTICATION frames are evaluated for rejection|[0 = No evaluation]; 1 = Evaluated. See Note 1.|
 |eval_probe_req|Control whether PROBE frames are evaluated for rejection|[0 = No evaluation]; 1 = Evaluated. See Note 1.|

--- a/dawn-config
+++ b/dawn-config
@@ -47,7 +47,7 @@ config metric 'global'
 	option min_number_to_kick '3'
 	option chan_util_avg_period '3'
 	option set_hostapd_nr '0'
-	option duration '0'
+	option duration '150'
 	option rrm_mode 'pat'
 
 config metric '802_11g'

--- a/src/utils/dawn_uci.c
+++ b/src/utils/dawn_uci.c
@@ -271,7 +271,7 @@ struct probe_metric_s uci_get_dawn_metric() {
         .bandwidth_threshold = 6,
         // CONFIG-G: chan_util_avg_period|Number of sampling periods to average channel utilization values over|[3]
         .chan_util_avg_period = 3,
-        // CONFIG-G: duration|802.11k BEACON request DURATION parameter|[0]
+        // CONFIG-G: duration|802.11k BEACON request measurement duration (TUs), also used as the 802.11v BSS-TM disassociation_timer and validity_period.  Must not be 0 because some clients refuse a zero-length measurement, leaving DAWN with no BEACON REPORT data to steer on|[150]
         .duration = 150,
         // CONFIG-G: rrm_mode|Preferred order for using Passive, Active or Table 802.11k BEACON information|[PAT] String of 'P', 'A' and / or 'T'
         .rrm_mode_mask = WLAN_RRM_CAPS_BEACON_REPORT_PASSIVE |


### PR DESCRIPTION
Closes #272 

The shipped `dawn-config` sets `option duration '0'` but the compiled-in default in [`uci_get_dawn_metric()` is at `150`](https://github.com/berlin-open-wireless-lab/DAWN/blob/806166bce0badb383f72e4942744dab9e26a591f/src/utils/dawn_uci.c#L275)  so a stock install runs with `0`. That value is passed straight through as the 802.11k beacon-request *measurement duration*, and some client firmware refuses a 0-TU measurement window, returning an empty report with the Refused bit set:

```
`BEACON-RESP-RX e4:bc:aa:bb:db:99 137 04 000000...`. 
```

DAWN's hearing map then only ever contains the AP the client is already on, so `better_ap_available()` has nothing to compare and steering silently never fires. On my cluster, the phone was sitting at -80 dBm for >10 min with another AP of the same ESS 1 m away with more than -40 dBm.

Setting `duration=150` immediately flipped the reports to mode `00` and steering worked. It's client-dependent (one Xiaomi phone refused, another tolerated `0`), so it looks like a per-device quirk rather than a default. 

Also, I would consider adding in `src/utils/dawn_uci.c`

```
if (ret.duration <= 0) {
    dawnlog_warning("duration=%d is invalid (0 disables 802.11k BEACON reports); using %d\n",
                    ret.duration, 150);
    ret.duration = 150;
}
```

To avoid duration to `0`. Looking to hear the opinion