### PR TITLE
dawn_iwinfo: drop local redefinition of IWINFO_BUFSIZE

### DIFF
--- a/src/utils/dawn_iwinfo.c
+++ b/src/utils/dawn_iwinfo.c
@@ -15,8 +15,6 @@ int get_rssi(const char *ifname, struct dawn_mac client_addr);
 
 int get_bandwidth(const char *ifname, struct dawn_mac client_addr, float *rx_rate, float *tx_rate);
 
-#define IWINFO_BUFSIZE    24 * 1024
-
 #define IWINFO_ESSID_MAX_SIZE    32
 
 int compare_essid_iwinfo(struct dawn_mac bssid_addr, struct dawn_mac bssid_addr_to_compare) {


### PR DESCRIPTION
`IWINFO_BUFSIZE` is already defined by libiwinfo's `<iwinfo.h>`, which is included at the top of `src/utils/dawn_iwinfo.c`. Redefining it locally with a different value (24 KiB here vs. 96 KiB in current libiwinfo) causes a compiler warning about macro redefinition, and — more importantly — means the `char buf[IWINFO_BUFSIZE]` stack buffers in this file are smaller than what libiwinfo may write into them (e.g. via `iw->assoclist()`).

Just drop the local `#define` and rely on the header's value.

No functional change beyond the buffer size following libiwinfo.