### PR TITLE
datastorage: use RCPI when probe signal is unavailable

### DIFF
--- a/src/storage/datastorage.c
+++ b/src/storage/datastorage.c
@@ -5,6 +5,7 @@
 #include "dawn_iwinfo.h"
 #include "dawn_uci.h"
 #include "mac_utils.h"
+#include "ieee80211_utils.h"
 
 #include "datastorage.h"
 #include "test_storage.h"
@@ -208,19 +209,27 @@ int get_band(int freq) {
 int eval_probe_metric(struct probe_entry_s* probe_entry, ap* ap_entry) {
     dawnlog_debug_func("Entering...");
     int score = 0;
+    int signal = probe_entry->signal;
+    bool signal_available = signal != 0;
 
-    if (probe_entry->signal != 0)
+    if (!signal_available && probe_entry->rcpi <= 220) {
+        signal = rcpi_to_rssi(probe_entry->rcpi);
+        signal_available = true;
+        dawnlog_trace("Scoring beacon report using RCPI %u as signal %d dBm\n",
+                      probe_entry->rcpi, signal);
+    }
+
+    if (signal_available)
     {
         dawn_mutex_require(&ap_array_mutex);
         dawn_mutex_require(&probe_array_mutex);
 
-        // TODO: Should RCPI be used here as well?
         int band = get_band(probe_entry->freq);
         score = dawn_metric.initial_score[band];
 
-        score += probe_entry->signal >= dawn_metric.rssi_val[band] ? dawn_metric.rssi[band] : 0;
-        score += probe_entry->signal <= dawn_metric.low_rssi_val[band] ? dawn_metric.low_rssi[band] : 0;
-        score += (probe_entry->signal - dawn_metric.rssi_center[band]) * dawn_metric.rssi_weight[band];
+        score += signal >= dawn_metric.rssi_val[band] ? dawn_metric.rssi[band] : 0;
+        score += signal <= dawn_metric.low_rssi_val[band] ? dawn_metric.low_rssi[band] : 0;
+        score += (signal - dawn_metric.rssi_center[band]) * dawn_metric.rssi_weight[band];
 
         // check if ap entry is available
         if (ap_entry != NULL) {


### PR DESCRIPTION
## Summary

Use beacon-report RCPI as an RSSI fallback when scoring a probe entry whose
`signal` field is zero.

The change is intentionally limited to `eval_probe_metric()`:

- a non-zero `signal` continues to be scored exactly as before;
- when `signal == 0` and RCPI is in the valid IEEE 802.11 range `0..220`, RCPI
  is converted with the existing `rcpi_to_rssi()` helper;
- RCPI values above `220` are not used and the entry remains unscored;
- the converted value is used by the existing stepped and graduated RSSI
  scoring calculations without changing their configuration or semantics.

## Problem

Beacon reports can populate a probe entry with a valid `rcpi` while leaving
`signal` at zero. The current implementation only enters the AP scoring path
when `probe_entry->signal != 0`.

As a result, an AP reported by the client can receive a score of zero even when
the beacon report contains usable signal-quality information. In a dual-band
deployment this can prevent a valid 5 GHz AP from becoming a steering candidate,
leaving the client on 2.4 GHz despite a good reported 5 GHz signal.

There is already a TODO in this function asking whether RCPI should be used.
DAWN also already provides `rcpi_to_rssi()`, so the conversion does not need to
be duplicated.

## Implementation

The patch copies `probe_entry->signal` into a local `signal` variable and tracks
whether a usable value is available. If the original signal is unavailable but
RCPI is valid, it converts RCPI to dBm and runs the existing scoring code with
that result.

This is a fallback, not a second score source. When both values are present,
the original non-zero `signal` remains authoritative and RCPI is ignored.

A trace message is emitted when the fallback is used:

```text
Scoring beacon report using RCPI <value> as signal <value> dBm
```

## Behaviour before and after

Before:

```text
signal == 0, valid RCPI present -> AP score remains 0
```

After:

```text
signal != 0                    -> unchanged RSSI scoring
signal == 0, RCPI in 0..220    -> score using rcpi_to_rssi(RCPI)
signal == 0, RCPI above 220    -> AP remains unscored
```

## Testing

- Built successfully for `aarch64_cortex-a53` using the official OpenWrt
  `25.12.5` mediatek/filogic SDK.
- Tested on two D-Link AQUILA PRO AI M60 A1 access points running OpenWrt
  `25.12.5`.
- Confirmed that ordinary entries with a non-zero `signal` retain their
  existing scoring behaviour.
- Confirmed the fallback at runtime with beacon-report-only entries:

| RCPI | Converted RSSI |
|---:|---:|
| `52` | `-84 dBm` |
| `78` | `-71 dBm` |
| `158` | `-31 dBm` |

- Confirmed that the converted RSSI feeds the existing AP score and allows the
  reported 5 GHz AP to participate in candidate comparison.
- Confirmed successful 802.11v BSS transition handling in the test deployment.

## Scope and compatibility

No UCI options or defaults are changed. No new scoring mechanism is introduced.
Deployments that already provide a non-zero probe `signal` retain the previous
behaviour. The fallback only affects entries that would otherwise skip RSSI and
AP scoring entirely despite carrying a valid RCPI value.
