### PR TITLE
datastorage: do not reset rcpi/rsni on expiry

### DIFF
--- a/src/storage/datastorage.c
+++ b/src/storage/datastorage.c
@@ -1187,8 +1187,6 @@ void remove_old_probe_entries(time_t current_time, long long int threshold) {
 
         if (((*i)->rcpi_timestamp < current_time - threshold))
         {
-            (*i)->rcpi = -1;
-            (*i)->rsni = -1;
             rcpi_expired = 1;
         }
 


### PR DESCRIPTION
`remove_old_probe_entries()` marks entries as `rcpi_expired` when their `rcpi_timestamp` is older than the threshold, and — before doing so — overwrites `rcpi` and `rsni` with `-1`.

The overwrite is unsafe: `eval_probe_metric()` reads `probe_entry->rcpi` on the scoring path (`src/storage/datastorage.c` around line 215):

```c
if (!signal_available && probe_entry->rcpi <= 220) {
    signal = rcpi_to_rssi(probe_entry->rcpi);
    ...
}
```

If the expiry pass writes `rcpi = -1` while a scorer is between the range check and the `rcpi_to_rssi()` call — or afterwards, when the scorer picks up the stale-then-`-1` value — `rcpi_to_rssi()` gets a bogus argument and the score is silently corrupted.

The overwrite is also unnecessary for the reap itself: entries whose `rcpi_timestamp` has aged out are already tracked via `rcpi_expired`, and once both `rcpi_expired` and `rssi_expired` are set the entry is unlinked and freed a few lines below. Incoming beacon reports overwrite `rcpi`/`rsni` unconditionally, so no observer depends on the `-1` sentinel.

This drops the two writes and relies solely on `rcpi_expired` to drive the reap.